### PR TITLE
[HOLD] feat(): Add Transfer to BancoSecurity

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,24 +20,77 @@ Or install it yourself as:
 
 ## Usage
 
-For now, the gem can only get recent deposits of Banco de Chile accounts (only Enterprise accounts have been tested). To add your credentials so the client can login, create the following initializer:
+For now, the gem can get recent deposits of Banco de Chile accounts (only Enterprise accounts have been tested) and BancoSecurity's accounts. To add your credentials so the client can login, create the following initializer:
 
 ```
 # config/initializers/bank_api.rb
 
 BankApi.configure do |config|
-  # Add the rut linked to the account
+  # Banco de Chile config
   config.bdc_user_rut = '12345678-9'
   # Add the account's password
   config.bdc_password = 'secretpassword'
-  # Add the account's enterprise rut
   config.bdc_company_rut = '98765432-1'
+
+  # Deposits config
   config.days_to_check = 3
+
+  # BancoSecurity config
+  config.banco_security.user_rut = '12345678-9'
+  config.banco_security.password = 'secretpassword'
+  config.banco_security.company_rut = '98765432-1'
+  config.banco_security.dynamic_card_entries = "[['A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', 'A10'], ['B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B9', 'B10'], ['C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8', 'C9', 'C10'], ['D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7', 'D8', 'D9', 'D10'], ['E1', 'E2', 'E3', 'E4', 'E5', 'E6', 'E7', 'E8', 'E9', 'E10']]"
 end
 
 ```
 
 The days to check is set by default to 6, and can be configured as seen in the initializer.
+
+For BancoSecurity's account there's also de posibility to make transfers to third party's accounts using the dynamic card. To use this feature, you must specify the `dynamic_card_entries` variable in the config, then call:
+
+```
+  BankApi.company_transfer({
+    amount: 1000,
+    name: "John Doe",
+    rut: "12.345.678-9",
+    account_number: "11111111",
+    bank: :banco_estado,
+    account_type: :cuenta_corriente,
+    email: "doe@platan.us",
+    comment: "This is a comment",
+    origin: "9.876.543-2"
+  })
+```
+
+If you don't setup the origin on the transfer's data, the default'll be `config.banco_security.company_rut`. You can also make transfers on batches:
+
+```
+  BankApi.company_batch_transfers([
+    {
+      amount: 1000,
+      name: "John Doe",
+      rut: "12.345.678-9",
+      account_number: "11111111",
+      bank: :banco_estado,
+      account_type: :cuenta_corriente,
+      email: "doe@platan.us",
+      comment: "This is a comment",
+      origin: "9.876.543-2"
+    }, {
+      amount: 2000,
+      name: "John Does",
+      rut: "12.345.678-9",
+      account_number: "11111111",
+      bank: :banco_estado,
+      account_type: :cuenta_corriente,
+      email: "does@platan.us",
+      comment: "This is a comment",
+      origin: "9.876.543-2"
+    }
+  ])
+```
+
+Checkout the available banks and account types in [this file](./lib/bank_api/utils/banco_security.rb).
 
 ## Development
 

--- a/lib/bank_api.rb
+++ b/lib/bank_api.rb
@@ -29,5 +29,14 @@ module BankApi
     def self.get_recent_company_deposits
       Clients::BancoSecurity::CompanyClient.new(BankApi.configuration).get_recent_deposits
     end
+
+    def self.company_transfer(transfer_data)
+      Clients::BancoSecurity::CompanyClient.new(BankApi.configuration).transfer(transfer_data)
+    end
+
+    def self.company_batch_transfers(transfers_data)
+      Clients::BancoSecurity::CompanyClient.new(BankApi.configuration)
+                                           .batch_transfers(transfers_data)
+    end
   end
 end

--- a/lib/bank_api/clients/banco_security/company_client.rb
+++ b/lib/bank_api/clients/banco_security/company_client.rb
@@ -1,21 +1,24 @@
 require 'timezone'
 
 require 'bank_api/clients/base_client'
+require 'bank_api/clients/banco_security/concerns/deposits'
+require 'bank_api/clients/banco_security/concerns/login'
+require 'bank_api/clients/banco_security/concerns/transfers'
+require 'bank_api/clients/navigation/banco_security/company_navigation'
+require 'bank_api/utils/banco_security'
 
 module BankApi::Clients::BancoSecurity
   class CompanyClient < BankApi::Clients::BaseClient
-    BASE_URL = 'https://empresas.bancosecurity.cl/'
-
-    DATE_COLUMN = 0
-    RUT_COLUMN = 2
-    AMOUNT_COLUMN = 5
-
-    NUMBER_OF_COLUMNS = 7
+    include BankApi::Clients::Navigation::BancoSecurity::CompanyNavigation
+    include BankApi::Clients::BancoSecurity::Deposits
+    include BankApi::Clients::BancoSecurity::Transfers
+    include BankApi::Clients::BancoSecurity::Login
 
     def initialize(config = BankApi::Configuration.new)
       @user_rut = config.banco_security.user_rut
       @password = config.banco_security.password
       @company_rut = config.banco_security.company_rut
+      @dynamic_card = config.banco_security.dynamic_card
       super
     end
 
@@ -29,122 +32,27 @@ module BankApi::Clients::BancoSecurity
       deposits
     end
 
-    def validate_credentials
-      raise BankApi::MissingCredentialsError if [
-        @user_rut,
-        @password,
-        @company_rut
-      ].any?(&:nil?)
+    def execute_transfer(transfer_data)
+      login
+      goto_company_dashboard(transfer_data[:origin] || @company_rut)
+      goto_transfer_form
+      submit_transfer_form(transfer_data)
+      fill_coordinates
     end
 
-    def login
-      goto_login
-      set_login_values
-      click_login_button
-    end
-
-    def goto_login
-      if session_expired?
-        browser.search("button:contains('Ingresa nuevamente')").click
-        browser.search("a:contains('Empresas')").click
-      else
-        browser.goto BASE_URL
-        browser.search('#mrcBtnIngresa').click
+    def execute_batch_transfers(transfers_data)
+      login
+      transfers_data.each do |transfer_data|
+        goto_company_dashboard(transfer_data[:origin] || @company_rut)
+        goto_transfer_form
+        submit_transfer_form(transfer_data)
+        fill_coordinates
       end
-    end
-
-    def session_expired?
-      browser.search("button:contains('Ingresa nuevamente')").any?
-    end
-
-    def set_login_values
-      browser.search('#lrut').set @user_rut
-      browser.search('#lpass').set @password
-    end
-
-    def click_login_button
-      browser.search('input[name="Entrar"]').click
-    end
-
-    def goto_company_dashboard
-      goto_frame query: '#mainFrame'
-      goto_frame(query: 'iframe[name="central"]', should_reset: false)
-      selenium_browser.execute_script(
-        "submitEntrar(true,1,#{without_verifier_digit_or_separators(@company_rut)}," +
-          "'#{verifier_digit(@company_rut)}');"
-      )
-    end
-
-    def goto_deposits
-      goto_frame query: '#topFrame'
-      selenium_browser.execute_script(
-        "MM_goToURL('parent.frames[\\'topFrame\\']','../menu/MenuTopTransferencias.asp'," +
-          "'parent.frames[\\'leftFrame\\']','../menu/MenuTransferencias.asp'," +
-          "'parent.frames[\\'mainFrame\\']','../../../noticias/transferencias.asp');"
-      )
-      selenium_browser.execute_script(
-        "MM_goToURL('parent.frames[\\'mainFrame\\']'," +
-          "'/empresas/RedirectConvivencia.asp?urlRedirect=CartolasTEF/Home/Index')"
-      )
-      goto_frame query: '#mainFrame'
-      goto_frame query: 'iframe[name="central"]', should_reset: false
-      wait('a.k-link:contains("Recibidas")').click
-    end
-
-    def select_deposits_range
-      browser.search('.BusquedaPorDefectoRecibida a:contains("búsqueda avanzada")').click
-      browser.search('#RadioEntreFechasRecibido').click
-      browser.search('#datePickerInicioRecibidas').set deposit_range[:start]
-      browser.search('#datePickerFinRecibido').set deposit_range[:end]
-      browser.search('.ContenedorSubmitRecibidas .btn_buscar').click
-      wait_for_deposits_fetch
-    end
-
-    def wait_for_deposits_fetch
-      goto_frame query: '#mainFrame'
-      goto_frame query: 'iframe[name="central"]', should_reset: false
-      wait('.k-loading-image') { browser.search('.k-loading-image').count.zero? }
-    end
-
-    def extract_deposits_from_html
-      deposits = []
-      deposit = {}
-      browser.search('#gridPrincipalRecibidas tbody td').each_with_index do |div, index|
-        if (index % NUMBER_OF_COLUMNS) == RUT_COLUMN
-          deposit[:rut] = div.text
-        elsif (index % NUMBER_OF_COLUMNS) == DATE_COLUMN
-          deposit[:date] = Date.parse div.text
-        elsif (index % NUMBER_OF_COLUMNS) == AMOUNT_COLUMN
-          deposit[:amount] = div.text.gsub(/[\. $]/, '').to_i
-        elsif ((index + 1) % NUMBER_OF_COLUMNS).zero?
-          deposits << deposit
-          deposit = {}
-        end
-      end
-      deposits
-    end
-
-    def deposit_range
-      @deposit_range ||= begin
-        timezone = Timezone['America/Santiago']
-        {
-          start: (timezone.utc_to_local(Time.now).to_date - @days_to_check).strftime('%d/%m/%Y'),
-          end: timezone.utc_to_local(Time.now).to_date.strftime('%d/%m/%Y')
-        }
-      end
-    end
-
-    def any_deposits?
-      browser.search(
-        ".k-label:contains('No se han encontrado transacciones para la búsqueda seleccionada.')"
-      ).any?
     end
 
     def goto_frame(query: nil, should_reset: true)
       sleep 1
-      browser.goto frame: :top if should_reset
-      frame = wait(query) if query
-      browser.goto(frame: frame)
+      super
       sleep 0.2
     end
   end

--- a/lib/bank_api/clients/banco_security/concerns/deposits.rb
+++ b/lib/bank_api/clients/banco_security/concerns/deposits.rb
@@ -1,0 +1,58 @@
+module BankApi::Clients::BancoSecurity
+  module Deposits
+    DATE_COLUMN = 0
+    RUT_COLUMN = 2
+    AMOUNT_COLUMN = 5
+
+    NUMBER_OF_COLUMNS = 7
+
+    def select_deposits_range
+      browser.search('.BusquedaPorDefectoRecibida a:contains("búsqueda avanzada")').click
+      browser.search('#RadioEntreFechasRecibido').click
+      browser.search('#datePickerInicioRecibidas').set deposit_range[:start]
+      browser.search('#datePickerFinRecibido').set deposit_range[:end]
+      browser.search('.ContenedorSubmitRecibidas .btn_buscar').click
+      wait_for_deposits_fetch
+    end
+
+    def wait_for_deposits_fetch
+      goto_frame query: '#mainFrame'
+      goto_frame query: 'iframe[name="central"]', should_reset: false
+      wait('.k-loading-image') { browser.search('.k-loading-image').count.zero? }
+    end
+
+    def extract_deposits_from_html
+      deposits = []
+      deposit = {}
+      browser.search('#gridPrincipalRecibidas tbody td').each_with_index do |div, index|
+        if (index % NUMBER_OF_COLUMNS) == RUT_COLUMN
+          deposit[:rut] = div.text
+        elsif (index % NUMBER_OF_COLUMNS) == DATE_COLUMN
+          deposit[:date] = Date.parse div.text
+        elsif (index % NUMBER_OF_COLUMNS) == AMOUNT_COLUMN
+          deposit[:amount] = div.text.gsub(/[\. $]/, '').to_i
+        elsif ((index + 1) % NUMBER_OF_COLUMNS).zero?
+          deposits << deposit
+          deposit = {}
+        end
+      end
+      deposits
+    end
+
+    def deposit_range
+      @deposit_range ||= begin
+        timezone = Timezone['America/Santiago']
+        {
+          start: (timezone.utc_to_local(Time.now).to_date - @days_to_check).strftime('%d/%m/%Y'),
+          end: timezone.utc_to_local(Time.now).to_date.strftime('%d/%m/%Y')
+        }
+      end
+    end
+
+    def any_deposits?
+      browser.search(
+        ".k-label:contains('No se han encontrado transacciones para la búsqueda seleccionada.')"
+      ).any?
+    end
+  end
+end

--- a/lib/bank_api/clients/banco_security/concerns/login.rb
+++ b/lib/bank_api/clients/banco_security/concerns/login.rb
@@ -1,0 +1,26 @@
+module BankApi::Clients::BancoSecurity
+  module Login
+    def validate_credentials
+      raise BankApi::MissingCredentialsError if [
+        @user_rut,
+        @password,
+        @company_rut
+      ].any?(&:nil?)
+    end
+
+    def login
+      goto_login
+      set_login_values
+      click_login_button
+    end
+
+    def set_login_values
+      browser.search('#lrut').set @user_rut
+      browser.search('#lpass').set @password
+    end
+
+    def click_login_button
+      browser.search('input[name="Entrar"]').click
+    end
+  end
+end

--- a/lib/bank_api/clients/banco_security/concerns/transfers.rb
+++ b/lib/bank_api/clients/banco_security/concerns/transfers.rb
@@ -1,0 +1,63 @@
+module BankApi::Clients::BancoSecurity
+  module Transfers
+    def validate_transfer_missing_data(transfer_data)
+      if [transfer_data[:origin] || @company_rut].all?(&:nil?)
+        raise BankApi::Transfer::MissingTransferData
+      end
+      if [
+        transfer_data[:amount],
+        transfer_data[:name],
+        transfer_data[:rut],
+        transfer_data[:account_number],
+        transfer_data[:email]
+      ].any?(&:nil?)
+        raise BankApi::Transfer::MissingTransferData
+      end
+    end
+
+    def validate_transfer_valid_data(transfer_data)
+      unless Utils::BancoSecurity.valid_banks.include? transfer_data[:bank]
+        raise BankApi::Transfer::InvalidBank
+      end
+      unless Utils::BancoSecurity.valid_account_types.include? transfer_data[:account_type]
+        raise BankApi::Transfer::InvalidAccountType
+      end
+    end
+
+    def submit_transfer_form(transfer_data)
+      set_transfer_transaction_data(transfer_data)
+      set_transfer_user_data(transfer_data)
+      browser.search('.active #enviar-paso-1').click
+    end
+
+    def set_transfer_user_data(transfer_data)
+      browser.search('.active #destinatario-nombre').set(transfer_data[:name])
+      browser.search('.active #destinatario-rut').set(transfer_data[:rut])
+      browser.search('.active #Email').set(transfer_data[:email])
+    end
+
+    def set_transfer_transaction_data(transfer_data)
+      browser.search('.active #Monto').set(transfer_data[:amount])
+      browser.search('.active #destinatario-cuenta').set(transfer_data[:account_number])
+      browser.search('.active #destinatario-banco').set(
+        Utils::BancoSecurity.bank_name(transfer_data[:bank])
+      )
+      browser.search(
+        ".active [name=\"tipo-cuenta\"][data-nombre=\"" +
+          Utils::BancoSecurity.account_type(transfer_data[:account_type]) +
+          "\"]"
+      ).set
+      browser.search('.active #Comentario').set(transfer_data[:comment])
+    end
+
+    def fill_coordinates
+      browser.search("[name=\"clave-dinamica-radio\"][value=\"tarjeta-clave\"]").set
+      (1..3).each do |i|
+        coordinate = browser.search("label[for=\"coordenada-#{i}\"").text
+        value = @dynamic_card.get_coordinate_value(coordinate)
+        browser.search("#coordenada-#{i}").set(value)
+      end
+      browser.search('#enviar-paso-2').click
+    end
+  end
+end

--- a/lib/bank_api/clients/base_client.rb
+++ b/lib/bank_api/clients/base_client.rb
@@ -16,6 +16,22 @@ module BankApi::Clients
       parse_entries(get_deposits)
     end
 
+    def transfer(transfer_data)
+      validate_credentials
+      validate_transfer_missing_data(transfer_data)
+      validate_transfer_valid_data(transfer_data)
+      execute_transfer(transfer_data)
+    end
+
+    def batch_transfers(transfers_data)
+      validate_credentials
+      transfers_data.each do |transfer_data|
+        validate_transfer_missing_data(transfer_data)
+        validate_transfer_valid_data(transfer_data)
+      end
+      execute_batch_transfers(transfers_data)
+    end
+
     private
 
     def validate_credentials
@@ -23,6 +39,22 @@ module BankApi::Clients
     end
 
     def get_deposits
+      raise NotImplementedError
+    end
+
+    def validate_transfer_missing_data(_transfer_data)
+      raise NotImplementedError
+    end
+
+    def validate_transfer_valid_data(_transfer_data)
+      raise NotImplementedError
+    end
+
+    def execute_transfer(_transfer_data)
+      raise NotImplementedError
+    end
+
+    def execute_batch_transfers(_transfers_data)
       raise NotImplementedError
     end
 
@@ -73,6 +105,12 @@ module BankApi::Clients
         count += interval
       end
       browser.search(query)
+    end
+
+    def goto_frame(query: nil, should_reset: true)
+      browser.goto frame: :top if should_reset
+      frame = wait(query) if query
+      browser.goto(frame: frame)
     end
 
     def parse_entries(entries)

--- a/lib/bank_api/clients/navigation/banco_security/company_navigation.rb
+++ b/lib/bank_api/clients/navigation/banco_security/company_navigation.rb
@@ -1,0 +1,69 @@
+module BankApi::Clients::Navigation
+  module BancoSecurity
+    module CompanyNavigation
+      BASE_URL = 'https://empresas.bancosecurity.cl/'
+
+      def goto_login
+        if session_expired?
+          browser.search("button:contains('Ingresa nuevamente')").click
+          browser.search("a:contains('Empresas')").click
+        else
+          browser.goto BASE_URL
+          browser.search('#mrcBtnIngresa').click
+        end
+      end
+
+      def session_expired?
+        browser.search("button:contains('Ingresa nuevamente')").any?
+      end
+
+      def goto_company_dashboard(company_rut = nil)
+        goto_frame query: '#topFrame'
+        if browser.search(".empresa a:contains(\"cambiar\")").any?
+          selenium_browser.execute_script(
+            "MM_goToURL('parent.frames[\\'mainFrame\\']'," +
+              "'/empresas/RedirectConvivencia.asp?urlRedirect=Perfilamiento/Home/Index')"
+          )
+        end
+        goto_frame query: '#mainFrame'
+        goto_frame(query: 'iframe[name="central"]', should_reset: false)
+        selenium_browser.execute_script(
+          "submitEntrar(true,1," +
+            "#{without_verifier_digit_or_separators(company_rut || @company_rut)}," +
+            "'#{verifier_digit(company_rut || @company_rut)}');"
+        )
+      end
+
+      def goto_deposits
+        goto_frame query: '#topFrame'
+        selenium_browser.execute_script(
+          "MM_goToURL('parent.frames[\\'topFrame\\']','../menu/MenuTopTransferencias.asp'," +
+            "'parent.frames[\\'leftFrame\\']','../menu/MenuTransferencias.asp'," +
+            "'parent.frames[\\'mainFrame\\']','../../../noticias/transferencias.asp');"
+        )
+        selenium_browser.execute_script(
+          "MM_goToURL('parent.frames[\\'mainFrame\\']'," +
+            "'/empresas/RedirectConvivencia.asp?urlRedirect=CartolasTEF/Home/Index')"
+        )
+        goto_frame query: '#mainFrame'
+        goto_frame query: 'iframe[name="central"]', should_reset: false
+        wait('a.k-link:contains("Recibidas")').click
+      end
+
+      def goto_transfer_form
+        goto_frame query: '#topFrame'
+        selenium_browser.execute_script(
+          "MM_goToURL('parent.frames[\\'topFrame\\']','../menu/MenuTopTransferencias.asp'," +
+            "'parent.frames[\\'leftFrame\\']','../menu/MenuTransferencias.asp'," +
+            "'parent.frames[\\'mainFrame\\']','../../../noticias/transferencias.asp');"
+        )
+        selenium_browser.execute_script(
+          "MM_goToURL('parent.frames[\\'mainFrame\\']'," +
+            "'/empresas/RedirectConvivencia.asp?urlRedirect=Transferencia/Tabs/Home')"
+        )
+        goto_frame query: '#mainFrame'
+        goto_frame query: 'iframe[name="central"]', should_reset: false
+      end
+    end
+  end
+end

--- a/lib/bank_api/configs/banco_security.rb
+++ b/lib/bank_api/configs/banco_security.rb
@@ -1,11 +1,18 @@
+require 'bank_api/values/dynamic_card'
+
 module BankApi::Configs
   class BancoSecurity
-    attr_accessor :user_rut, :password, :company_rut
+    attr_accessor :user_rut, :password, :company_rut, :dynamic_card_entries
 
     def initialize
       @user_rut = nil
       @password = nil
       @company_rut = nil
+      @dynamic_card_entries = nil
+    end
+
+    def dynamic_card
+      DynamicCard.new(@dynamic_card_entries) unless @dynamic_card_entries.nil?
     end
   end
 end

--- a/lib/bank_api/exceptions.rb
+++ b/lib/bank_api/exceptions.rb
@@ -1,3 +1,8 @@
 module BankApi
   class MissingCredentialsError < StandardError; end
+  module Transfer
+    class InvalidBank < StandardError; end
+    class InvalidAccountType < StandardError; end
+    class MissingTransferData < StandardError; end
+  end
 end

--- a/lib/bank_api/utils/banco_security.rb
+++ b/lib/bank_api/utils/banco_security.rb
@@ -1,0 +1,49 @@
+module Utils
+  module BancoSecurity
+    extend self
+
+    BANKS = {
+      banco_de_chile: 'Banco Chile-Edwards-Citi',
+      banco_consorcio: 'Banco Consorcio',
+      banco_del_desarrollo: 'Banco del Desarrollo',
+      banco_estado: 'Banco Estado',
+      banco_falabella: 'Banco Falabella',
+      banco_internacional: 'Banco Internacional',
+      banco_itau: 'Banco Ita\u00FA',
+      banco_paris: 'Banco Paris',
+      banco_rabobank: 'Banco Rabobank',
+      banco_ripley: 'Banco Ripley',
+      banco_santander: 'Banco Santander',
+      banco_security: 'Banco Security',
+      bbva: 'BBVA',
+      bci: 'BCI',
+      bice: 'BICE',
+      coopeuch: 'COOPEUCH',
+      corpbanca: 'Corpbanca',
+      hsbc: 'HSBC BANK',
+      scotiabank: 'Scotiabank'
+    }
+
+    def bank_name(bank)
+      BANKS[bank]
+    end
+
+    def valid_banks
+      BANKS.keys.sort
+    end
+
+    ACCOUNT_TYPES = {
+      cuenta_corriente: 'Cuenta Corriente',
+      cuenta_vista: 'Cuenta Vista',
+      cuenta_de_ahorro: 'Cuenta de Ahorro'
+    }
+
+    def account_type(type)
+      ACCOUNT_TYPES[type]
+    end
+
+    def valid_account_types
+      ACCOUNT_TYPES.keys.sort
+    end
+  end
+end

--- a/lib/bank_api/values/dynamic_card.rb
+++ b/lib/bank_api/values/dynamic_card.rb
@@ -1,0 +1,13 @@
+require 'yaml'
+
+class DynamicCard
+  def initialize(entries)
+    @coordinates_array = YAML::safe_load(entries.gsub(/,\s*([^\s])/, ', \1'))
+  end
+
+  def get_coordinate_value(coordinate)
+    col = ('A'..'J').to_a.index(coordinate[0])
+    row = (1..5).to_a.index(coordinate[1].to_i)
+    @coordinates_array[row][col]
+  end
+end

--- a/spec/bank_api/clients/banco_security/concerns/deposits_spec.rb
+++ b/spec/bank_api/clients/banco_security/concerns/deposits_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+RSpec.describe BankApi::Clients::BancoSecurity::Deposits do
+  let(:browser) { double(config: { wait_timeout: 5.0, wait_interval: 0.2 }) }
+  let(:div) { double(text: 'text') }
+  let(:dynamic_card) { double }
+
+  class DummyClass < BankApi::Clients::BaseClient
+    include BankApi::Clients::BancoSecurity::Deposits
+
+    def initialize
+      @user_rut = '12.345.678-9'
+      @password = 'password'
+      @company_rut = '98.765.432-1'
+      @days_to_check = 6
+    end
+  end
+
+  let(:dummy) { DummyClass.new }
+
+  let(:lines) do
+    [
+      '01/01/2018', '', '12.345.678-9', '', '', '$ 1.000', '',
+      '01/01/2018', '', '12.345.678-9', '', '', '$ 2.000', '',
+      '01/01/2018', '', '12.345.678-9', '', '', '$ 3.000', '',
+      '01/01/2018', '', '12.345.678-9', '', '', '$ 4.000', ''
+    ].map { |t| double(text: t) }
+  end
+
+  before do
+    dummy.instance_variable_set(:@dynamic_card, dynamic_card)
+    allow(dummy).to receive(:browser).and_return(browser)
+
+    allow(browser).to receive(:search).and_return(div)
+    allow(browser).to receive(:search).with('#gridPrincipalRecibidas tbody td').and_return(lines)
+    allow(browser).to receive(:goto)
+    allow(div).to receive(:any?).and_return(true)
+    allow(div).to receive(:count).and_return(1)
+    allow(div).to receive(:click)
+    allow(div).to receive(:set)
+  end
+
+  it "implements select_deposits_range" do
+    expect { dummy.select_deposits_range }.not_to raise_error
+  end
+
+  it "implements extract_deposits_from_html" do
+    expect { dummy.extract_deposits_from_html }.not_to raise_error
+  end
+
+  context "with deposits" do
+    it "returns deposits" do
+      expect(dummy.extract_deposits_from_html).to eq(
+        [
+          {
+            rut: '12.345.678-9',
+            date: Date.parse('01/01/2018'),
+            amount: 1000
+          },
+          {
+            rut: '12.345.678-9',
+            date: Date.parse('01/01/2018'),
+            amount: 2000
+          },
+          {
+            rut: '12.345.678-9',
+            date: Date.parse('01/01/2018'),
+            amount: 3000
+          },
+          {
+            rut: '12.345.678-9',
+            date: Date.parse('01/01/2018'),
+            amount: 4000
+          }
+        ]
+      )
+    end
+  end
+
+  context "without deposits" do
+    before do
+      allow(browser).to receive(:search).with('#gridPrincipalRecibidas tbody td').and_return([])
+    end
+
+    it "returns empty array" do
+      expect(dummy.extract_deposits_from_html).to eq([])
+    end
+  end
+end

--- a/spec/bank_api/clients/banco_security/concerns/login_spec.rb
+++ b/spec/bank_api/clients/banco_security/concerns/login_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe BankApi::Clients::BancoSecurity::Login, client: true do
+  let(:browser) { double(config: { wait_timeout: 5.0, wait_interval: 0.2 }) }
+  let(:div) { double(text: 'text') }
+  let(:dynamic_card) { double }
+
+  class DummyClass < BankApi::Clients::BaseClient
+    include BankApi::Clients::BancoSecurity::Login
+
+    def initialize
+      @user_rut = '12.345.678-9'
+      @password = 'password'
+      @company_rut = '98.765.432-1'
+      @days_to_check = 6
+    end
+  end
+
+  let(:dummy) { DummyClass.new }
+
+  before do
+    dummy.instance_variable_set(:@dynamic_card, dynamic_card)
+    allow(dummy).to receive(:browser).and_return(browser)
+    allow(dummy).to receive(:goto_login)
+
+    allow(browser).to receive(:search).and_return(div)
+    allow(browser).to receive(:goto)
+    allow(div).to receive(:click)
+    allow(div).to receive(:set)
+  end
+
+  it "implements login" do
+    expect { dummy.login }.not_to raise_error
+  end
+
+  it "implements set_login_values" do
+    expect { dummy.set_login_values }.not_to raise_error
+  end
+
+  it "implements click_login_button" do
+    expect { dummy.click_login_button }.not_to raise_error
+  end
+
+  fit "logins with correct values" do
+    expect_to_set(browser, query: "#lrut", value: '12.345.678-9')
+    expect_to_set(browser, query: "#lpass", value: 'password')
+
+    dummy.set_login_values
+  end
+end

--- a/spec/bank_api/clients/banco_security/concerns/transfers_spec.rb
+++ b/spec/bank_api/clients/banco_security/concerns/transfers_spec.rb
@@ -1,0 +1,129 @@
+require 'spec_helper'
+
+RSpec.describe BankApi::Clients::BancoSecurity::Transfers, client: true do
+  let(:browser) { double(config: { wait_timeout: 5.0, wait_interval: 0.2 }) }
+  let(:div) { double(text: 'text') }
+  let(:dynamic_card) { double }
+
+  class DummyClass < BankApi::Clients::BaseClient
+    include BankApi::Clients::BancoSecurity::Transfers
+
+    def initialize
+      @user_rut = '12.345.678-9'
+      @password = 'password'
+      @company_rut = '98.765.432-1'
+      @days_to_check = 6
+    end
+  end
+
+  let(:dummy) { DummyClass.new }
+  let(:transfer_data) do
+    {
+      amount: 10000,
+      name: 'John Doe',
+      rut: '32.165.498-7',
+      account_number: '11111111',
+      bank: :banco_estado,
+      account_type: :cuenta_corriente,
+      email: 'doe@platan.us',
+      comment: 'Comment'
+    }
+  end
+  let(:dummy) { DummyClass.new }
+
+  let(:transfers_data) { [transfer_data] }
+
+  before do
+    dummy.instance_variable_set(:@dynamic_card, dynamic_card)
+    allow(dummy).to receive(:browser).and_return(browser)
+
+    allow(browser).to receive(:search).and_return(div)
+    allow(browser).to receive(:goto)
+    allow(div).to receive(:click)
+    allow(div).to receive(:set)
+
+    allow(dynamic_card).to receive(:get_coordinate_value).and_return('11')
+  end
+
+  it "implements submit_transfer_form" do
+    expect { dummy.submit_transfer_form(transfer_data) }.not_to raise_error
+  end
+
+  it "implements fill_coordinates" do
+    expect { dummy.fill_coordinates }.not_to raise_error
+  end
+
+  describe "validations" do
+    context "with valid data" do
+      it "doesn't raise error" do
+        expect { dummy.validate_transfer_missing_data(transfer_data) }.not_to raise_error
+        expect { dummy.validate_transfer_valid_data(transfer_data) }.not_to raise_error
+      end
+    end
+
+    context "with invalid data" do
+      context "with missing origin" do
+        before { dummy.instance_variable_set(:@company_rut, nil) }
+        after { dummy.instance_variable_set(:@company_rut, '98.765.432-1') }
+
+        it "raises BankApi::Transfer::MissingTransferData" do
+          expect { dummy.validate_transfer_missing_data(transfer_data) }.to raise_error(
+            BankApi::Transfer::MissingTransferData
+          )
+        end
+      end
+
+      context "with missing transfer_data" do
+        let(:transfer_data) { { amount: 10000 } }
+
+        it "raises BankApi::Transfer::MissingTransferData" do
+          expect { dummy.validate_transfer_missing_data(transfer_data) }.to raise_error(
+            BankApi::Transfer::MissingTransferData
+          )
+        end
+      end
+
+      context "with invalid bank" do
+        let(:transfer_data) { { bank: :invalid_bank } }
+
+        it "raises BankApi::Transfer::InvalidBank" do
+          expect { dummy.validate_transfer_valid_data(transfer_data) }.to raise_error(
+            BankApi::Transfer::InvalidBank
+          )
+        end
+      end
+
+      context "with invalid account type" do
+        let(:transfer_data) { { bank: :banco_estado, account_type: :invalid_account_type } }
+
+        it "raises BankApi::Transfer::InvalidAccountType" do
+          expect { dummy.validate_transfer_valid_data(transfer_data) }.to raise_error(
+            BankApi::Transfer::InvalidAccountType
+          )
+        end
+      end
+    end
+  end
+
+  it 'fills the form with the transfer data' do
+    expect_to_set(browser, query: ".active #destinatario-nombre", value: "John Doe")
+    expect_to_set(browser, query: ".active #destinatario-rut", value: "32.165.498-7")
+    expect_to_set(browser, query: ".active #destinatario-cuenta", value: "11111111")
+    expect_to_set(browser, query: ".active #destinatario-banco", value: "Banco Estado")
+    expect_to_set(browser, query: ".active #Monto", value: 10000)
+    expect_to_set(browser, query: ".active #Email", value: "doe@platan.us")
+    expect_to_set(browser, query: ".active #Comentario", value: "Comment")
+    expect_to_set(
+      browser,
+      query: ".active [name=\"tipo-cuenta\"][data-nombre=\"Cuenta Corriente\"]"
+    )
+
+    dummy.submit_transfer_form(transfer_data)
+  end
+
+  it "fills coordinates" do
+    expect(div).to receive(:set).with('11').exactly(3).times
+
+    dummy.fill_coordinates
+  end
+end

--- a/spec/bank_api_spec.rb
+++ b/spec/bank_api_spec.rb
@@ -10,10 +10,24 @@ RSpec.describe BankApi do
     BankApi.get_bdc_recent_company_deposits
   end
 
-  it 'calls BancoSecurity::CompanyClient' do
+  it 'calls get_recent_deposits on BancoSecurity::CompanyClient' do
     expect_any_instance_of(BankApi::Clients::BancoSecurity::CompanyClient)
       .to receive(:get_recent_deposits)
 
     BankApi::BancoSecurity.get_recent_company_deposits
+  end
+
+  it 'calls transfer on  BancoSecurity::CompanyClient' do
+    expect_any_instance_of(BankApi::Clients::BancoSecurity::CompanyClient)
+      .to receive(:transfer)
+
+    BankApi::BancoSecurity.company_transfer({})
+  end
+
+  it 'calls batch_transfers BancoSecurity::CompanyClient' do
+    expect_any_instance_of(BankApi::Clients::BancoSecurity::CompanyClient)
+      .to receive(:batch_transfers)
+
+    BankApi::BancoSecurity.company_batch_transfers([])
   end
 end

--- a/spec/pincers_helpers.rb
+++ b/spec/pincers_helpers.rb
@@ -1,0 +1,19 @@
+module PincersHelpers
+  def expect_to_set(browser, query:, value: nil)
+    expect(browser).to receive(:search).with(query).and_return(element_mock)
+    if value.nil?
+      expect(element_mock).to receive(:set)
+    else
+      expect(element_mock).to receive(:set).with(value)
+    end
+  end
+
+  def element_mock
+    @element_mock ||= begin
+      element_mock = double
+      allow(element_mock).to receive(:set)
+      allow(element_mock).to receive(:click)
+      element_mock
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,10 @@
+require "./spec/pincers_helpers"
 require "bundler/setup"
 require "bank_api"
 
 RSpec.configure do |config|
+  config.include PincersHelpers, client: true
+
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 


### PR DESCRIPTION
# Cambios
- Refactor de `CompanyClient` del Banco Security
- Se agregan los métodos `BankApi::BancoSecurity::company_transfer` y `BankApi::BancoSecurity::company_batch_transfers`.

* OJO *: Lo que se ha probado hasta ahora es ingresar las coordenadas, hay que revisar si efectivamente se realiza la transferencia.