### PR TITLE
fix(banco_security): return if no_deposits?

### DIFF
--- a/lib/bank_api/clients/banco_security/concerns/deposits.rb
+++ b/lib/bank_api/clients/banco_security/concerns/deposits.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 module BankApi::Clients::BancoSecurity
   module Deposits
     DATE_COLUMN = 0
@@ -19,6 +20,7 @@ module BankApi::Clients::BancoSecurity
     def wait_for_deposits_fetch
       goto_frame query: '#mainFrame'
       goto_frame query: 'iframe[name="central"]', should_reset: false
+      sleep 0.5
       wait('.k-loading-image') { browser.search('.k-loading-image').count.zero? }
     end
 
@@ -72,7 +74,7 @@ module BankApi::Clients::BancoSecurity
     def any_deposits?
       browser.search(
         ".k-label:contains('No se han encontrado transacciones para la búsqueda seleccionada.')"
-      ).any?
+      ).none?
     end
 
     def total_results

--- a/spec/bank_api/clients/banco_security/concerns/deposits_spec.rb
+++ b/spec/bank_api/clients/banco_security/concerns/deposits_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe BankApi::Clients::BancoSecurity::Deposits do
     allow(browser).to receive(:search).with('#gridPrincipalRecibidas tbody td').and_return(lines)
     allow(browser).to receive(:goto)
     allow(div).to receive(:any?).and_return(true)
+    allow(div).to receive(:none?).and_return(true)
     allow(div).to receive(:count).and_return(1)
     allow(div).to receive(:click)
     allow(div).to receive(:set)


### PR DESCRIPTION
# Cambios
- Se estaba devolviendo `[]` cuando habían depósitos :shame:
- Se agrega otro delay, porque la página del banco hace dos FETCH, uno antes de ingresar los filtros, y otro después. A veces se demoraba más en el primero, y entregaba esos depósitos.