### PR TITLE
Fix banco security deposit pagination

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (10.0.2)
     childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
@@ -23,6 +24,9 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     rake (10.5.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -52,6 +56,7 @@ DEPENDENCIES
   bank_api!
   bundler (~> 1.16)
   pry
+  pry-byebug
   rake (~> 10.0)
   rspec (~> 3.0)
 

--- a/bank_api.gemspec
+++ b/bank_api.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry-byebug"
 end

--- a/lib/bank_api/clients/banco_security/company_client.rb
+++ b/lib/bank_api/clients/banco_security/company_client.rb
@@ -19,6 +19,7 @@ module BankApi::Clients::BancoSecurity
       @password = config.banco_security.password
       @company_rut = config.banco_security.company_rut
       @dynamic_card = config.banco_security.dynamic_card
+      @page_size = config.banco_security.page_size
       super
     end
 

--- a/lib/bank_api/configs/banco_security.rb
+++ b/lib/bank_api/configs/banco_security.rb
@@ -2,13 +2,14 @@ require 'bank_api/values/dynamic_card'
 
 module BankApi::Configs
   class BancoSecurity
-    attr_accessor :user_rut, :password, :company_rut, :dynamic_card_entries
+    attr_accessor :user_rut, :password, :company_rut, :page_size, :dynamic_card_entries
 
     def initialize
       @user_rut = nil
       @password = nil
       @company_rut = nil
       @dynamic_card_entries = nil
+      @page_size = 30
     end
 
     def dynamic_card

--- a/lib/bank_api/exceptions.rb
+++ b/lib/bank_api/exceptions.rb
@@ -1,5 +1,9 @@
 module BankApi
   class MissingCredentialsError < StandardError; end
+  module Deposit
+    class QuantityError < StandardError; end
+    class PaginationError < StandardError; end
+  end
   module Transfer
     class InvalidBank < StandardError; end
     class InvalidAccountType < StandardError; end

--- a/spec/bank_api/clients/banco_security/concerns/login_spec.rb
+++ b/spec/bank_api/clients/banco_security/concerns/login_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe BankApi::Clients::BancoSecurity::Login, client: true do
       @password = 'password'
       @company_rut = '98.765.432-1'
       @days_to_check = 6
+      @page_size = 30
     end
   end
 

--- a/spec/bank_api/clients/banco_security/concerns/transfers_spec.rb
+++ b/spec/bank_api/clients/banco_security/concerns/transfers_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe BankApi::Clients::BancoSecurity::Transfers, client: true do
       @password = 'password'
       @company_rut = '98.765.432-1'
       @days_to_check = 6
+      @page_size = 30
     end
   end
 


### PR DESCRIPTION
# Cambios
- Se agrega cambio de tamaño de paginación
- Se agrega la espera por el cambio de tamaño de paginación
- Se valida que hayan tantos depósitos como lo indica la paginación, y que el último visto sea igual a la cantidad de depósitos.