### PR TITLE
fix(): Remove hash and Datetime from signature

### DIFF
--- a/lib/bank_api/sign_deposits.rb
+++ b/lib/bank_api/sign_deposits.rb
@@ -1,5 +1,3 @@
-require 'digest/sha1'
-
 module BankApi::SignDeposits
   extend self
 
@@ -35,7 +33,7 @@ module BankApi::SignDeposits
 
   def entry_signature(entry, occurrencies)
     key = entry_key(entry)
-    Digest::SHA1.hexdigest("#{key}|#{occurrencies}") + Time.now.to_i.to_s
+    "#{key}|#{occurrencies}"
   end
 
   def entry_key(entry)

--- a/spec/bank_api/sign_deposits_spec.rb
+++ b/spec/bank_api/sign_deposits_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe BankApi::SignDeposits do
     ]
   end
 
-  let(:expected_signature) { '6e652e430638ab1c6fa631553c21344972017c48666' }
+  let(:expected_signature) { '25000|2017-03-03|12345678-9|security|1' }
 
   before { allow(Time).to receive(:now).and_return(666) }
 


### PR DESCRIPTION
# Cambios
- Firma de los depósitos ya no se hashea.
- Firma ya no tiene el `Datetime`