### PR TITLE
chore(): Ensure browser.close

### DIFF
--- a/lib/bank_api/clients/banco_de_chile_company_client.rb
+++ b/lib/bank_api/clients/banco_de_chile_company_client.rb
@@ -41,8 +41,9 @@ module BankApi::Clients
       login
       deposits_first_try = get_deposits_try
       deposits_second_try = get_deposits_try
-      browser.close
       deposits_first_try == deposits_second_try ? deposits_first_try : []
+    ensure
+      browser.close
     end
 
     def get_deposits_try

--- a/lib/bank_api/clients/banco_security/company_client.rb
+++ b/lib/bank_api/clients/banco_security/company_client.rb
@@ -35,8 +35,9 @@ module BankApi::Clients::BancoSecurity
       select_deposits_range
       deposits = deposits_from_txt
       validate_deposits(deposits) unless deposits.empty?
-      browser.close
       deposits
+    ensure
+      browser.close
     end
 
     def execute_transfer(transfer_data)
@@ -45,6 +46,8 @@ module BankApi::Clients::BancoSecurity
       goto_transfer_form
       submit_transfer_form(transfer_data)
       fill_coordinates
+    ensure
+      browser.close
     end
 
     def execute_batch_transfers(transfers_data)
@@ -55,6 +58,8 @@ module BankApi::Clients::BancoSecurity
         submit_transfer_form(transfer_data)
         fill_coordinates
       end
+    ensure
+      browser.close
     end
 
     def goto_frame(query: nil, should_reset: true)

--- a/spec/bank_api/clients/banco_de_chile_company_client_spec.rb
+++ b/spec/bank_api/clients/banco_de_chile_company_client_spec.rb
@@ -201,5 +201,34 @@ RSpec.describe BankApi::Clients::BancoDeChileCompanyClient do
         expect(subject.get_recent_deposits.count).to eq(0)
       end
     end
+
+    describe "ensure browser.close" do
+      before do
+        mock_validate_credentials
+        expect(browser).to receive(:close)
+      end
+
+      context "without error" do
+        before do
+          mock_site_navigation
+          expect(subject).to receive(:any_deposits?).and_return(true).exactly(2).times
+          expect(subject).to receive(:total_results).and_return(30).exactly(2)
+        end
+
+        it "calls browser.close" do
+          subject.get_recent_deposits
+        end
+      end
+
+      context "with error" do
+        before do
+          allow(subject).to receive(:get_deposits_try).and_raise(StandardError)
+        end
+
+        it "calls browser.close" do
+          expect { subject.get_recent_deposits }.to raise_error(StandardError)
+        end
+      end
+    end
   end
 end

--- a/spec/bank_api/clients/banco_security/company_client_spec.rb
+++ b/spec/bank_api/clients/banco_security/company_client_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe BankApi::Clients::BancoSecurity::CompanyClient do
         allow(subject).to receive(:any_deposits?).and_return(false)
       end
 
-      fit 'returns empty array' do
+      it 'returns empty array' do
         expect(subject.get_recent_deposits).to eq([])
       end
     end
@@ -192,6 +192,31 @@ RSpec.describe BankApi::Clients::BancoSecurity::CompanyClient do
             BankApi::Deposit::QuantityError, "Expected 50 deposits," +
               " got 30."
           )
+        end
+      end
+    end
+
+    describe "ensure browser.close" do
+      before do
+        mock_validate_credentials
+        mock_site_navigation
+        allow(subject).to receive(:any_deposits?).and_return(false)
+        expect(browser).to receive(:close)
+      end
+
+      context "without error" do
+        it "calls browser.close" do
+          subject.get_recent_deposits
+        end
+      end
+
+      context "with error" do
+        before do
+          allow(subject).to receive(:deposits_from_txt).and_raise(StandardError)
+        end
+
+        it "calls browser.close" do
+          expect { subject.get_recent_deposits }.to raise_error(StandardError)
         end
       end
     end
@@ -253,6 +278,32 @@ RSpec.describe BankApi::Clients::BancoSecurity::CompanyClient do
       expect(subject).to receive(:fill_coordinates)
 
       subject.transfer(transfer_data)
+    end
+
+    describe "ensure browser.close" do
+      before do
+        expect(browser).to receive(:close)
+      end
+
+      context "without error" do
+        before do
+          expect(subject).to receive(:fill_coordinates)
+        end
+
+        it "calls browser.close" do
+          subject.transfer(transfer_data)
+        end
+      end
+
+      context "with error" do
+        before do
+          allow(subject).to receive(:submit_transfer_form).and_raise(StandardError)
+        end
+
+        it "calls browser.close" do
+          expect { subject.transfer(transfer_data) }.to raise_error(StandardError)
+        end
+      end
     end
   end
 
@@ -330,6 +381,32 @@ RSpec.describe BankApi::Clients::BancoSecurity::CompanyClient do
       expect(subject).to receive(:fill_coordinates).exactly(2).times
 
       subject.batch_transfers(transfers_data)
+    end
+
+    describe "ensure browser.close" do
+      before do
+        expect(browser).to receive(:close)
+      end
+
+      context "without error" do
+        before do
+          expect(subject).to receive(:fill_coordinates).exactly(2).times
+        end
+
+        it "calls browser.close" do
+          subject.batch_transfers(transfers_data)
+        end
+      end
+
+      context "with error" do
+        before do
+          allow(subject).to receive(:submit_transfer_form).and_raise(StandardError)
+        end
+
+        it "calls browser.close" do
+          expect { subject.batch_transfers(transfers_data) }.to raise_error(StandardError)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Cambios
- Se agrega `ensure -> browser.close` en depósitos de ambos bancos, y en transferencias del banco security