### PR TITLE
feat(): Alternative credentials

### DIFF
--- a/lib/bank_api.rb
+++ b/lib/bank_api.rb
@@ -26,6 +26,19 @@ module BankApi
   end
 
   module BancoSecurity
+    def self.with_credentials(user_rut:, password:, company_rut:, dynamic_card_entries: nil)
+      config = Configuration.new
+
+      config.banco_security.user_rut = user_rut
+      config.banco_security.password = password
+      config.banco_security.company_rut = company_rut
+      config.banco_security.dynamic_card_entries = (
+        dynamic_card_entries || BankApi.configuration.banco_security.dynamic_card_entries
+      )
+
+      Clients::BancoSecurity::CompanyClient.new(config)
+    end
+
     def self.get_recent_company_deposits
       Clients::BancoSecurity::CompanyClient.new(BankApi.configuration).get_recent_deposits
     end

--- a/lib/bank_api/clients/banco_security/company_client.rb
+++ b/lib/bank_api/clients/banco_security/company_client.rb
@@ -20,7 +20,6 @@ module BankApi::Clients::BancoSecurity
       @password = config.banco_security.password
       @company_rut = config.banco_security.company_rut
       @dynamic_card = config.banco_security.dynamic_card
-      @page_size = config.banco_security.page_size
       super
     end
 
@@ -55,6 +54,18 @@ module BankApi::Clients::BancoSecurity
         submit_transfer_form(transfer_data)
         fill_coordinates
       end
+    end
+
+    def get_recent_company_deposits
+      get_recent_deposits
+    end
+
+    def company_transfer(transfer_data)
+      transfer(transfer_data)
+    end
+
+    def company_batch_transfers(transfers_data)
+      batch_transfers(transfers_data)
     end
 
     def goto_frame(query: nil, should_reset: true)

--- a/lib/bank_api/configs/banco_security.rb
+++ b/lib/bank_api/configs/banco_security.rb
@@ -2,14 +2,13 @@ require 'bank_api/values/dynamic_card'
 
 module BankApi::Configs
   class BancoSecurity
-    attr_accessor :user_rut, :password, :company_rut, :page_size, :dynamic_card_entries
+    attr_accessor :user_rut, :password, :company_rut, :dynamic_card_entries
 
     def initialize
       @user_rut = nil
       @password = nil
       @company_rut = nil
       @dynamic_card_entries = nil
-      @page_size = 30
     end
 
     def dynamic_card

--- a/spec/bank_api/clients/banco_security/company_client_spec.rb
+++ b/spec/bank_api/clients/banco_security/company_client_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe BankApi::Clients::BancoSecurity::CompanyClient do
           user_rut: '',
           password: '',
           company_rut: '',
-          page_size: 50,
           dynamic_card:  dynamic_card
         ),
         days_to_check: 6
@@ -330,6 +329,33 @@ RSpec.describe BankApi::Clients::BancoSecurity::CompanyClient do
       expect(subject).to receive(:fill_coordinates).exactly(2).times
 
       subject.batch_transfers(transfers_data)
+    end
+  end
+
+  describe "#company methods" do
+    describe "#get_recent_company_deposits" do
+      it "calls get_recent_deposits" do
+        expect(subject).to receive(:get_recent_deposits)
+        subject.get_recent_company_deposits
+      end
+    end
+
+    describe "#company_transfer" do
+      let(:transfer_data) { double }
+
+      it "calls get_recent_deposits" do
+        expect(subject).to receive(:transfer).with(transfer_data)
+        subject.company_transfer(transfer_data)
+      end
+    end
+
+    describe "#company_batch_transfers" do
+      let(:transfer_data) { double }
+
+      it "calls get_recent_deposits" do
+        expect(subject).to receive(:batch_transfers).with(transfer_data)
+        subject.company_batch_transfers(transfer_data)
+      end
     end
   end
 end

--- a/spec/bank_api/clients/banco_security/concerns/deposits_spec.rb
+++ b/spec/bank_api/clients/banco_security/concerns/deposits_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe BankApi::Clients::BancoSecurity::Deposits do
       @password = 'password'
       @company_rut = '98.765.432-1'
       @days_to_check = 6
-      @page_size = 30
     end
   end
 
@@ -32,10 +31,6 @@ RSpec.describe BankApi::Clients::BancoSecurity::Deposits do
   let(:txt_url) { "https://file.txt" }
 
   let(:page_info) { double(text: "1 - 4 de 4", any?: true) }
-
-  def mock_set_page_size
-    allow(dummy).to receive(:set_page_size)
-  end
 
   def mock_wait_for_deposits_fetch
     allow(dummy).to receive(:wait_for_deposits_fetch)
@@ -61,7 +56,6 @@ RSpec.describe BankApi::Clients::BancoSecurity::Deposits do
     allow(div).to receive(:click)
     allow(div).to receive(:set)
 
-    mock_set_page_size
     mock_wait_for_deposits_fetch
     mock_wait_for_next_page
   end

--- a/spec/bank_api/clients/banco_security/concerns/login_spec.rb
+++ b/spec/bank_api/clients/banco_security/concerns/login_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe BankApi::Clients::BancoSecurity::Login, client: true do
       @password = 'password'
       @company_rut = '98.765.432-1'
       @days_to_check = 6
-      @page_size = 30
     end
   end
 

--- a/spec/bank_api/clients/banco_security/concerns/transfers_spec.rb
+++ b/spec/bank_api/clients/banco_security/concerns/transfers_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe BankApi::Clients::BancoSecurity::Transfers, client: true do
       @password = 'password'
       @company_rut = '98.765.432-1'
       @days_to_check = 6
-      @page_size = 30
     end
   end
 

--- a/spec/bank_api_spec.rb
+++ b/spec/bank_api_spec.rb
@@ -10,24 +10,51 @@ RSpec.describe BankApi do
     BankApi.get_bdc_recent_company_deposits
   end
 
-  it 'calls get_recent_deposits on BancoSecurity::CompanyClient' do
-    expect_any_instance_of(BankApi::Clients::BancoSecurity::CompanyClient)
-      .to receive(:get_recent_deposits)
+  describe "BancoSecurity" do
+    it 'calls get_recent_deposits on BancoSecurity::CompanyClient' do
+      expect_any_instance_of(BankApi::Clients::BancoSecurity::CompanyClient)
+        .to receive(:get_recent_deposits)
 
-    BankApi::BancoSecurity.get_recent_company_deposits
-  end
+      BankApi::BancoSecurity.get_recent_company_deposits
+    end
 
-  it 'calls transfer on  BancoSecurity::CompanyClient' do
-    expect_any_instance_of(BankApi::Clients::BancoSecurity::CompanyClient)
-      .to receive(:transfer)
+    it 'calls transfer on  BancoSecurity::CompanyClient' do
+      expect_any_instance_of(BankApi::Clients::BancoSecurity::CompanyClient)
+        .to receive(:transfer)
 
-    BankApi::BancoSecurity.company_transfer({})
-  end
+      BankApi::BancoSecurity.company_transfer({})
+    end
 
-  it 'calls batch_transfers BancoSecurity::CompanyClient' do
-    expect_any_instance_of(BankApi::Clients::BancoSecurity::CompanyClient)
-      .to receive(:batch_transfers)
+    it 'calls batch_transfers BancoSecurity::CompanyClient' do
+      expect_any_instance_of(BankApi::Clients::BancoSecurity::CompanyClient)
+        .to receive(:batch_transfers)
 
-    BankApi::BancoSecurity.company_batch_transfers([])
+      BankApi::BancoSecurity.company_batch_transfers([])
+    end
+
+    context "with_credentials" do
+      let(:credentials) { { user_rut: "2-k", password: "password", company_rut: "1-k" } }
+
+      it 'calls get_recent_deposits on BancoSecurity::CompanyClient' do
+        expect_any_instance_of(BankApi::Clients::BancoSecurity::CompanyClient)
+          .to receive(:get_recent_deposits)
+
+        BankApi::BancoSecurity.with_credentials(**credentials).get_recent_company_deposits
+      end
+
+      it 'calls transfer on  BancoSecurity::CompanyClient' do
+        expect_any_instance_of(BankApi::Clients::BancoSecurity::CompanyClient)
+          .to receive(:transfer)
+
+        BankApi::BancoSecurity.with_credentials(**credentials).company_transfer({})
+      end
+
+      it 'calls batch_transfers BancoSecurity::CompanyClient' do
+        expect_any_instance_of(BankApi::Clients::BancoSecurity::CompanyClient)
+          .to receive(:batch_transfers)
+
+        BankApi::BancoSecurity.with_credentials(**credentials).company_batch_transfers([])
+      end
+    end
   end
 end


### PR DESCRIPTION
# Cambios:
- Se agrega `.with_credentials` a cliente del banco security que permite llamar a métodos del banco security con una cuenta alternativa:
```
BankApi::BancoSecurity.with_credentials(
  user_rut: '12345678-9',
  password: 'password',
  company_rut: '98765432-1',
  dynamic_card_entries: "[['A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', 'A10'], ['B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B9', 'B10'], ['C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8', 'C9', 'C10'], ['D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7', 'D8', 'D9', 'D10'], ['E1', 'E2', 'E3', 'E4', 'E5', 'E6', 'E7', 'E8', 'E9', 'E10']]"
)
```