### PR TITLE
feat(): Pending transfers

### DIFF
--- a/lib/bank_api.rb
+++ b/lib/bank_api.rb
@@ -51,5 +51,10 @@ module BankApi
       Clients::BancoSecurity::CompanyClient.new(BankApi.configuration)
                                            .batch_transfers(transfers_data)
     end
+
+    def self.pending_company_transfer(trx_id, transfer_data = {})
+      Clients::BancoSecurity::CompanyClient.new(BankApi.configuration)
+                                           .pending_transfer(trx_id, transfer_data)
+    end
   end
 end

--- a/lib/bank_api/clients/banco_security/company_client.rb
+++ b/lib/bank_api/clients/banco_security/company_client.rb
@@ -43,7 +43,7 @@ module BankApi::Clients::BancoSecurity
       goto_company_dashboard(transfer_data[:origin] || @company_rut)
       goto_transfer_form
       submit_transfer_form(transfer_data)
-      fill_coordinates
+      fill_transfer_coordinates
     end
 
     def execute_batch_transfers(transfers_data)
@@ -52,7 +52,7 @@ module BankApi::Clients::BancoSecurity
         goto_company_dashboard(transfer_data[:origin] || @company_rut)
         goto_transfer_form
         submit_transfer_form(transfer_data)
-        fill_coordinates
+        fill_transfer_coordinates
       end
     end
 

--- a/lib/bank_api/clients/banco_security/concerns/login.rb
+++ b/lib/bank_api/clients/banco_security/concerns/login.rb
@@ -1,11 +1,15 @@
 module BankApi::Clients::BancoSecurity
   module Login
     def validate_credentials
-      raise BankApi::MissingCredentialsError if [
+      raise BankApi::MissingCredentialsError, "Missing credentials" if [
         @user_rut,
         @password,
         @company_rut
       ].any?(&:nil?)
+    end
+
+    def validate_dynamic_card_presence
+      raise BankApi::MissingCredentialsError, "Missing dynamic card" if @dynamic_card.nil?
     end
 
     def login

--- a/lib/bank_api/clients/banco_security/concerns/pending_transfers.rb
+++ b/lib/bank_api/clients/banco_security/concerns/pending_transfers.rb
@@ -1,0 +1,122 @@
+module BankApi::Clients::BancoSecurity
+  module PendingTransfers
+    TRX_ID_COLUMN = 0
+    DATETIME_COLUMN = 1
+    ORIGIN_COLUMN = 2
+    ACCOUNT_COLUMN = 3
+    AMOUNT_COLUMN = 4
+
+    TRANSFER_DETAILS_ACCOUNT_COLUMN = 0
+    TRANSFER_DETAILS_RUT_COLUMN = 4
+    TRANSFER_DETAILS_AMOUNT_COLUMN = 7
+
+    def find_pending_transfer(trx_id)
+      pending_operations_table = browser.search(".Marco table")[1]
+      transfers = pending_operations_table.search("tr").drop(1).map do |tr|
+        build_pending_transfer(
+          tr.search("td").map(&:text).drop(1),
+          tr.search("td").first.search("input")
+        )
+      end
+      transfers.find { |t| t[:trx_id] == trx_id }
+    end
+
+    def select_pending_transfer(pending_transfer)
+      pending_transfer[:input].click
+      select_pending_transfer_method
+      selenium_browser.execute_script("PagarValores();")
+    end
+
+    def select_pending_transfer_method
+      set_pending_transfer_method_as_dynamic_card
+    end
+
+    def set_pending_transfer_method_as_digipass
+      browser.search("input[value=\"TK\"]").click
+    end
+
+    def set_pending_transfer_method_as_dynamic_card
+      browser.search("input[value=\"TC\"]").click
+    end
+
+    def set_pending_transfer_method_as_fea
+      browser.search("input[value=\"FE\"]").click
+    end
+
+    def fill_pending_transfer_coordinates
+      coordinates_table = browser.search(".Marco table")[2]
+      coordinates = coordinates_table.search("td span").map(&:text)
+      coordinates_inputs = coordinates_table.search("td input")
+
+      3.times.each do |i|
+        coordinate = coordinates[i]
+        value = @dynamic_card.get_coordinate_value(coordinate)
+        coordinates_inputs[i].set(value)
+      end
+      selenium_browser.execute_script("_Validar('');")
+    end
+
+    def validate_pending_transfer_data(transfer_data)
+      wait("span:contains('Monto a Transferir')")
+      validate_rut(transfer_data[:rut]) unless transfer_data[:rut].nil?
+      validate_account(transfer_data[:account]) unless transfer_data[:account].nil?
+      validate_origin(transfer_data[:origin]) unless transfer_data[:origin].nil?
+      validate_amount(transfer_data[:amount]) unless transfer_data[:amount].nil?
+    end
+
+    def transfer_details_table
+      browser.search(".Marco table")[1].search("td").map(&:text)
+    end
+
+    def validate_rut(rut)
+      transfer_rut = transfer_details_table[TRANSFER_DETAILS_RUT_COLUMN]
+      unless strip_rut(rut) == strip_rut(transfer_rut)
+        raise ::BankApi::Transfer::InvalidAccountData,
+          "#{rut} doesn't match transfer's rut #{transfer_rut}"
+      end
+    end
+
+    def validate_amount(amount)
+      transfer_amount = transfer_details_table.last.tr("$.", "").to_i
+      unless amount == transfer_amount
+        raise ::BankApi::Transfer::InvalidAmount,
+          "#{amount} doesn't match transfer's amount #{transfer_amount}"
+      end
+    end
+
+    def validate_account(account)
+      transfer_account = transfer_details_table[TRANSFER_DETAILS_ACCOUNT_COLUMN]
+      unless format_account(account) == format_account(transfer_account)
+        raise ::BankApi::Transfer::InvalidAccountData,
+          "#{account} doesn't match transfer's account #{transfer_account}"
+      end
+    end
+
+    def validate_origin(origin)
+      transfer_origin = browser.search(".Marco table")[0].search("td").first.text
+      unless format_account(origin) == format_account(transfer_origin)
+        raise ::BankApi::Transfer::InvalidAccountData,
+          "#{origin} doesn't match transfer's origin #{transfer_origin}"
+      end
+    end
+
+    def build_pending_transfer(row, input)
+      {
+        trx_id: row[TRX_ID_COLUMN].strip,
+        datetime: row[DATETIME_COLUMN].strip,
+        origin: row[ORIGIN_COLUMN].strip,
+        account: row[ACCOUNT_COLUMN].strip,
+        amount: row[AMOUNT_COLUMN].strip.delete(".").to_i,
+        input: input
+      }
+    end
+
+    def format_account(number)
+      number.match(/0*([0-9]*)/)[1]
+    end
+
+    def strip_rut(rut)
+      rut.tr(".-", "")
+    end
+  end
+end

--- a/lib/bank_api/clients/banco_security/concerns/transfers.rb
+++ b/lib/bank_api/clients/banco_security/concerns/transfers.rb
@@ -50,7 +50,7 @@ module BankApi::Clients::BancoSecurity
       browser.search('.active #Comentario').set(transfer_data[:comment])
     end
 
-    def fill_coordinates
+    def fill_transfer_coordinates
       browser.search("[name=\"clave-dinamica-radio\"][value=\"tarjeta-clave\"]").set
       (1..3).each do |i|
         coordinate = browser.search("label[for=\"coordenada-#{i}\"").text

--- a/lib/bank_api/clients/base_client.rb
+++ b/lib/bank_api/clients/base_client.rb
@@ -24,6 +24,12 @@ module BankApi::Clients
       execute_transfer(transfer_data)
     end
 
+    def pending_transfer(trx_id, transfer_data = {})
+      validate_credentials
+      validate_dynamic_card_presence
+      execute_pending_transfer(trx_id, transfer_data)
+    end
+
     def batch_transfers(transfers_data)
       validate_credentials
       validate_dynamic_card_presence

--- a/lib/bank_api/clients/base_client.rb
+++ b/lib/bank_api/clients/base_client.rb
@@ -18,6 +18,7 @@ module BankApi::Clients
 
     def transfer(transfer_data)
       validate_credentials
+      validate_dynamic_card_presence
       validate_transfer_missing_data(transfer_data)
       validate_transfer_valid_data(transfer_data)
       execute_transfer(transfer_data)
@@ -25,6 +26,7 @@ module BankApi::Clients
 
     def batch_transfers(transfers_data)
       validate_credentials
+      validate_dynamic_card_presence
       transfers_data.each do |transfer_data|
         validate_transfer_missing_data(transfer_data)
         validate_transfer_valid_data(transfer_data)
@@ -39,6 +41,10 @@ module BankApi::Clients
     end
 
     def validate_credentials
+      raise NotImplementedError
+    end
+
+    def validate_dynamic_card_presence
       raise NotImplementedError
     end
 

--- a/lib/bank_api/clients/navigation/banco_security/company_navigation.rb
+++ b/lib/bank_api/clients/navigation/banco_security/company_navigation.rb
@@ -34,6 +34,20 @@ module BankApi::Clients::Navigation
         )
       end
 
+      def goto_pending_transfers
+        goto_frame query: '#topFrame'
+        selenium_browser.execute_script(
+          "MM_goToURL('parent.frames[\\'topFrame\\']','../menu/MenuTopInicio.asp'," +
+            "'parent.frames[\\'leftFrame\\']','../menu/MenuInicio.asp'," +
+            "'parent.frames[\\'mainFrame\\']','../../../noticias/arriba_noticias.asp');"
+        )
+        selenium_browser.execute_script(
+          "MM_goToURL('parent.frames[\\'mainFrame\\']'," +
+            "'/empresas/cashmngfinal/op_sel.asp');"
+        )
+        goto_frame query: '#mainFrame'
+      end
+
       def goto_deposits
         goto_frame query: '#topFrame'
         selenium_browser.execute_script(

--- a/lib/bank_api/exceptions.rb
+++ b/lib/bank_api/exceptions.rb
@@ -6,7 +6,10 @@ module BankApi
   end
   module Transfer
     class InvalidBank < StandardError; end
+    class InvalidAmount < StandardError; end
     class InvalidAccountType < StandardError; end
+    class InvalidAccountData < StandardError; end
+    class InvalidTrxId < StandardError; end
     class MissingTransferData < StandardError; end
   end
 end

--- a/spec/bank_api/clients/banco_security/company_client_spec.rb
+++ b/spec/bank_api/clients/banco_security/company_client_spec.rb
@@ -69,6 +69,10 @@ RSpec.describe BankApi::Clients::BancoSecurity::CompanyClient do
     allow(subject).to receive(:validate_credentials)
   end
 
+  def mock_validate_dynamic_card_presence
+    allow(subject).to receive(:validate_dynamic_card_presence)
+  end
+
   def mock_validate_transfer_missing_data
     allow(subject).to receive(:validate_transfer_missing_data)
   end
@@ -212,6 +216,7 @@ RSpec.describe BankApi::Clients::BancoSecurity::CompanyClient do
 
     before do
       mock_validate_credentials
+      mock_validate_dynamic_card_presence
       mock_validate_transfer_missing_data
       mock_validate_transfer_valid_data
       mock_site_navigation
@@ -283,6 +288,7 @@ RSpec.describe BankApi::Clients::BancoSecurity::CompanyClient do
 
     before do
       mock_validate_credentials
+      mock_validate_dynamic_card_presence
       mock_validate_transfer_missing_data
       mock_validate_transfer_valid_data
       mock_site_navigation

--- a/spec/bank_api/clients/banco_security/company_client_spec.rb
+++ b/spec/bank_api/clients/banco_security/company_client_spec.rb
@@ -248,8 +248,8 @@ RSpec.describe BankApi::Clients::BancoSecurity::CompanyClient do
       subject.transfer(transfer_data)
     end
 
-    it "calls fill_coordinates" do
-      expect(subject).to receive(:fill_coordinates)
+    it "calls fill_transfer_coordinates" do
+      expect(subject).to receive(:fill_transfer_coordinates)
 
       subject.transfer(transfer_data)
     end
@@ -325,8 +325,8 @@ RSpec.describe BankApi::Clients::BancoSecurity::CompanyClient do
       subject.batch_transfers(transfers_data)
     end
 
-    it "calls fill_coordinates" do
-      expect(subject).to receive(:fill_coordinates).exactly(2).times
+    it "calls fill_transfer_coordinates" do
+      expect(subject).to receive(:fill_transfer_coordinates).exactly(2).times
 
       subject.batch_transfers(transfers_data)
     end

--- a/spec/bank_api/clients/banco_security/concerns/pending_transfers_spec.rb
+++ b/spec/bank_api/clients/banco_security/concerns/pending_transfers_spec.rb
@@ -1,0 +1,216 @@
+require 'spec_helper'
+
+RSpec.describe BankApi::Clients::BancoSecurity::PendingTransfers, client: true do
+  let(:browser) { double(config: { wait_timeout: 0.5, wait_interval: 0.1 }) }
+  let(:selenium_browser) { double }
+  let(:div) { double(text: 'text') }
+  let(:dynamic_card) { double }
+
+  class DummyClass < BankApi::Clients::BaseClient
+    include BankApi::Clients::BancoSecurity::PendingTransfers
+
+    def initialize
+      @user_rut = '12.345.678-9'
+      @password = 'password'
+      @company_rut = '98.765.432-1'
+      @days_to_check = 6
+    end
+  end
+
+  let(:dummy) { DummyClass.new }
+  let(:transfer_data) { { rut: '32.165.498-7' } }
+
+  def text(_text)
+    double(text: _text)
+  end
+
+  def mock_table(table)
+    table_div = double
+    table_rows = table.map { |_x| double }
+    allow(table_div).to receive(:search).with("tr").and_return(table_rows)
+    allow(table_div).to receive(:search).with("td").and_return(table.flatten)
+    table.zip(table_rows).each do |row, tr|
+      allow(tr).to receive(:search).with("td").and_return(row)
+    end
+    table_div
+  end
+
+  def mock_pending_trasfers_table
+    allow(pending_transfers_table_div).to receive(:search).with("tr")
+                                                          .and_return(pending_transfers_table)
+  end
+
+  def mock_dynamic_card
+    dummy.instance_variable_set(:@dynamic_card, dynamic_card)
+    allow(dynamic_card).to receive(:get_coordinate_value).and_return('11')
+  end
+
+  def mock_browser
+    allow(dummy).to receive(:browser).and_return(browser)
+    allow(dummy).to receive(:selenium_browser).and_return(selenium_browser)
+    allow(selenium_browser).to receive(:execute_script)
+
+    allow(browser).to receive_messages(goto: nil, search: div)
+    allow(div).to receive_messages(click: nil, set: nil)
+  end
+
+  def mock_wait_for_transfer_details
+    allow(dummy).to receive(:wait).with("span:contains('Monto a Transferir')")
+  end
+
+  before do
+    mock_browser
+    mock_dynamic_card
+    mock_wait_for_transfer_details
+  end
+
+  describe "find_pending_transfer" do
+    let(:trx_id) { "13131313" }
+    let(:check) { double(text: "") }
+    let(:pending_transfers_table_div) { double }
+    let(:table_rows) { pending_transfers_table.map { |_x| double } }
+    let(:pending_transfers_table) do
+      [
+        [text(""), text("trx_id"), text("date"), text("origin"), text("account"), text("amount")],
+        [text(""), text("1"), text("01/01/2018 18:26"), text("1111"), text("2222"), text("10000")],
+        [text(""), text("2"), text("01/01/2018 18:26"), text("1111"), text("2222"), text("20000")],
+        [text(""), text("3"), text("01/01/2018 18:26"), text("1111"), text("2222"), text("30000")],
+        [check, text(trx_id), text("01/01/2018 18:26"), text("3333"), text("2222"), text("1000")],
+        [text(""), text("4"), text("01/01/2018 18:26"), text("1111"), text("2222"), text("40000")]
+      ]
+    end
+    let(:expected_transfer) do
+      {
+        trx_id: "13131313", datetime: "01/01/2018 18:26", origin: "3333",
+        account: "2222", amount: 1000, input: check
+      }
+    end
+
+    before do
+      allow(browser).to receive(:search)
+        .with(".Marco table").and_return(
+          ["No tiene operaciones pendientes", pending_transfers_table_div]
+        )
+      allow(pending_transfers_table_div).to receive(:search).with("tr").and_return(table_rows)
+      pending_transfers_table.each do |row|
+        allow(row[0]).to receive(:search).with("input").and_return(row[0])
+      end
+      pending_transfers_table.zip(table_rows).each do |row, tr|
+        allow(tr).to receive(:search).with("td").and_return(row)
+      end
+      pending_transfers_table.each do |row|
+        allow(row[0]).to receive(:search).with("input").and_return(row[0])
+      end
+    end
+
+    it "returns the expected transfer" do
+      expect(dummy.find_pending_transfer(trx_id)).to eq(expected_transfer)
+    end
+
+    context "without transaction" do
+      it "returns the expected transfer" do
+        expect(dummy.find_pending_transfer("141414")).to be nil
+      end
+    end
+  end
+
+  describe "validate_pending_transfer_data" do
+    let(:check) { double }
+    let(:transfer_data) do
+      { rut: "12345678-9", account: "131313", origin: "1234567", amount: 1000 }
+    end
+    let(:origin_table) do
+      [
+        [text("1234567")],
+        [text("$ 1.000")],
+        [text("$ 0")],
+        [text("$ 1.000")],
+        [text("$ 999.999.999")]
+      ]
+    end
+    let(:transfer_details_table) do
+      [
+        [text("131313")],
+        [text("Banco Falabella")],
+        [text("Cuenta Corriente")],
+        [text("Dres")],
+        [text("12.345.678-9")],
+        [text("r2d2@fintual.cl")],
+        [text("Coment")],
+        [text("$ 1000")]
+      ]
+    end
+
+    before do
+      allow(browser).to receive(:search)
+        .with(".Marco table").and_return(
+          [mock_table(origin_table), mock_table(transfer_details_table)]
+        )
+    end
+
+    it { expect { dummy.validate_pending_transfer_data(transfer_data) }.not_to raise_error }
+
+    context "with different rut" do
+      let(:transfer_data) { { rut: "12345678-0" } }
+
+      it "raises error" do
+        expect { dummy.validate_pending_transfer_data(transfer_data) }.to raise_error(
+          BankApi::Transfer::InvalidAccountData,
+          "12345678-0 doesn't match transfer's rut 12.345.678-9"
+        )
+      end
+    end
+
+    context "with different account" do
+      let(:transfer_data) { { account: "141414" } }
+
+      it "raises error" do
+        expect { dummy.validate_pending_transfer_data(transfer_data) }.to raise_error(
+          BankApi::Transfer::InvalidAccountData,
+          "141414 doesn't match transfer's account 131313"
+        )
+      end
+    end
+
+    context "with different origin" do
+      let(:transfer_data) { { origin: "7654321" } }
+
+      it "raises error" do
+        expect { dummy.validate_pending_transfer_data(transfer_data) }.to raise_error(
+          BankApi::Transfer::InvalidAccountData,
+          "7654321 doesn't match transfer's origin 1234567"
+        )
+      end
+    end
+
+    context "with different amount" do
+      let(:transfer_data) { { amount: 2000 } }
+
+      it "raises error" do
+        expect { dummy.validate_pending_transfer_data(transfer_data) }.to raise_error(
+          BankApi::Transfer::InvalidAmount,
+          "2000 doesn't match transfer's amount 1000"
+        )
+      end
+    end
+  end
+
+  describe "fill_pending_transfer_coordinates" do
+    let(:coordinates_table) { double }
+    let(:coordinates_texts) { ["A1", "B2", "C3"].map { |x| text(x) } }
+    let(:coordinates_inputs) { coordinates_texts.map { double } }
+
+    before do
+      allow(browser).to receive(:search).with(".Marco table").and_return(
+        ["Origin details", "Tranfer details", coordinates_table]
+      )
+      allow(coordinates_table).to receive(:search).with("td span").and_return(coordinates_texts)
+      allow(coordinates_table).to receive(:search).with("td input").and_return(coordinates_inputs)
+    end
+
+    it "fills coordinates inputs" do
+      coordinates_inputs.each { |i| expect(i).to receive(:set).with("11") }
+      dummy.fill_pending_transfer_coordinates
+    end
+  end
+end

--- a/spec/bank_api/clients/banco_security/concerns/transfers_spec.rb
+++ b/spec/bank_api/clients/banco_security/concerns/transfers_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe BankApi::Clients::BancoSecurity::Transfers, client: true do
     expect { dummy.submit_transfer_form(transfer_data) }.not_to raise_error
   end
 
-  it "implements fill_coordinates" do
-    expect { dummy.fill_coordinates }.not_to raise_error
+  it "implements fill_transfer_coordinates" do
+    expect { dummy.fill_transfer_coordinates }.not_to raise_error
   end
 
   describe "validations" do
@@ -124,6 +124,6 @@ RSpec.describe BankApi::Clients::BancoSecurity::Transfers, client: true do
   it "fills coordinates" do
     expect(div).to receive(:set).with('11').exactly(3).times
 
-    dummy.fill_coordinates
+    dummy.fill_transfer_coordinates
   end
 end

--- a/spec/bank_api/clients/base_client_spec.rb
+++ b/spec/bank_api/clients/base_client_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe BankApi::Clients::BaseClient do
     allow(subject).to receive(:execute_transfer)
   end
 
+  def mock_execute_pending_transfer
+    allow(subject).to receive(:execute_pending_transfer)
+  end
+
   def mock_execute_batch_transfers
     allow(subject).to receive(:execute_batch_transfers)
   end
@@ -84,6 +88,25 @@ RSpec.describe BankApi::Clients::BaseClient do
       expect(subject).to receive(:execute_transfer).with(transfer_data)
 
       subject.transfer(transfer_data)
+    end
+  end
+
+  describe "#pending_transfer" do
+    let(:trx_id) { "131313" }
+    let(:transfer_data) { { rut: "123456-7" } }
+
+    before do
+      mock_validate_credentials
+      mock_validate_dynamic_card_presence
+      mock_execute_pending_transfer
+    end
+
+    it "validates and executes pending_transfer" do
+      expect(subject).to receive(:validate_credentials)
+      expect(subject).to receive(:validate_dynamic_card_presence)
+      expect(subject).to receive(:execute_pending_transfer).with(trx_id, transfer_data)
+
+      subject.pending_transfer(trx_id, transfer_data)
     end
   end
 

--- a/spec/bank_api/clients/base_client_spec.rb
+++ b/spec/bank_api/clients/base_client_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe BankApi::Clients::BaseClient do
     allow(subject).to receive(:validate_credentials)
   end
 
+  def mock_validate_dynamic_card_presence
+    allow(subject).to receive(:validate_dynamic_card_presence)
+  end
+
   def mock_get_deposits
     allow(subject).to receive(:get_deposits).and_return([])
   end
@@ -67,6 +71,7 @@ RSpec.describe BankApi::Clients::BaseClient do
   describe "#transfer" do
     before do
       mock_validate_credentials
+      mock_validate_dynamic_card_presence
       mock_validate_transfer_missing_data
       mock_validate_transfer_valid_data
       mock_execute_transfer
@@ -85,6 +90,7 @@ RSpec.describe BankApi::Clients::BaseClient do
   describe "#batch_transfers" do
     before do
       mock_validate_credentials
+      mock_validate_dynamic_card_presence
       mock_validate_transfer_missing_data
       mock_validate_transfer_valid_data
       mock_execute_transfer
@@ -104,6 +110,20 @@ RSpec.describe BankApi::Clients::BaseClient do
 
   context "without validate_credentials implementation on transfer" do
     before do
+      mock_validate_dynamic_card_presence
+      mock_validate_transfer_missing_data
+      mock_validate_transfer_valid_data
+      mock_execute_transfer
+    end
+
+    it "raises NotImplementedError" do
+      expect { subject.transfer(transfer_data) }.to raise_error(NotImplementedError)
+    end
+  end
+
+  context "without validate_dynamic_card_presence implementation on transfer" do
+    before do
+      mock_validate_credentials
       mock_validate_transfer_missing_data
       mock_validate_transfer_valid_data
       mock_execute_transfer
@@ -117,6 +137,7 @@ RSpec.describe BankApi::Clients::BaseClient do
   context "without validate_transfer_missing_data implementation" do
     before do
       mock_validate_credentials
+      mock_validate_dynamic_card_presence
       mock_validate_transfer_valid_data
       mock_execute_transfer
     end
@@ -129,6 +150,7 @@ RSpec.describe BankApi::Clients::BaseClient do
   context "without validate_transfer_valid_data implementation" do
     before do
       mock_validate_credentials
+      mock_validate_dynamic_card_presence
       mock_validate_transfer_missing_data
       mock_execute_transfer
     end
@@ -141,6 +163,7 @@ RSpec.describe BankApi::Clients::BaseClient do
   context "without execute_transfer implementation" do
     before do
       mock_validate_credentials
+      mock_validate_dynamic_card_presence
       mock_validate_transfer_missing_data
       mock_validate_transfer_valid_data
     end

--- a/spec/bank_api_spec.rb
+++ b/spec/bank_api_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe BankApi do
       BankApi::BancoSecurity.company_batch_transfers([])
     end
 
+    it 'calls execute_pending_transfer BancoSecurity::CompanyClient' do
+      expect_any_instance_of(BankApi::Clients::BancoSecurity::CompanyClient)
+        .to receive(:pending_transfer).with('trx_id', {})
+
+      BankApi::BancoSecurity.pending_company_transfer('trx_id', {})
+    end
+
     context "with_credentials" do
       let(:credentials) { { user_rut: "2-k", password: "password", company_rut: "1-k" } }
 


### PR DESCRIPTION
# Cambios
- Se agrega la ejecución de transferencias pendientes dado un `trx_id`, y esta se puede validar con kwargs opcionales:

```
BankApi::BancoSecurity.pending_company_transfer("trx_id", rut: "12345678-9", account: "11111", origin: "21313213", amount: 2000)
```