### PR TITLE
Account statement

### DIFF
--- a/lib/bank_api.rb
+++ b/lib/bank_api.rb
@@ -3,6 +3,8 @@ require "bank_api/configs/banco_security"
 require "bank_api/version"
 require 'bank_api/clients/banco_de_chile_company_client'
 require 'bank_api/clients/banco_security/company_client'
+require 'bank_api/utils/rut'
+require 'bank_api/utils/account'
 
 module BankApi
   class << self
@@ -28,6 +30,16 @@ module BankApi
   module BancoSecurity
     def self.get_recent_company_deposits
       Clients::BancoSecurity::CompanyClient.new(BankApi.configuration).get_recent_deposits
+    end
+
+    def self.get_company_statement(account_number:, month:, year:, company_rut: nil)
+      Clients::BancoSecurity::CompanyClient.new(BankApi.configuration)
+                                           .get_statement(
+                                             account_number: account_number,
+                                             month: month,
+                                             year: year,
+                                             company_rut: company_rut
+                                           )
     end
 
     def self.company_transfer(transfer_data)

--- a/lib/bank_api.rb
+++ b/lib/bank_api.rb
@@ -32,6 +32,14 @@ module BankApi
       Clients::BancoSecurity::CompanyClient.new(BankApi.configuration).get_recent_deposits
     end
 
+    def self.get_company_current_statement(account_number:, company_rut: nil)
+      Clients::BancoSecurity::CompanyClient.new(BankApi.configuration)
+                                           .get_current_statement(
+                                             account_number: account_number,
+                                             company_rut: company_rut
+                                           )
+    end
+
     def self.get_company_statement(account_number:, month:, year:, company_rut: nil)
       Clients::BancoSecurity::CompanyClient.new(BankApi.configuration)
                                            .get_statement(

--- a/lib/bank_api/clients/banco_security/company_client.rb
+++ b/lib/bank_api/clients/banco_security/company_client.rb
@@ -42,6 +42,16 @@ module BankApi::Clients::BancoSecurity
       browser.close
     end
 
+    def get_current_statement_of_account(account_number, company_rut)
+      login
+      goto_company_dashboard(company_rut || @company_rut)
+      goto_current_statement
+      select_current_statement(account_number)
+      account_current_statement_from_txt
+    ensure
+      browser.close
+    end
+
     def get_statement_of_month(account_number, month, year, company_rut)
       login
       goto_company_dashboard(company_rut || @company_rut)
@@ -72,6 +82,12 @@ module BankApi::Clients::BancoSecurity
       end
     ensure
       browser.close
+    end
+
+    def get_company_current_statement(account_number:, company_rut: nil)
+      get_current_statement(
+        account_number: account_number, company_rut: company_rut
+      )
     end
 
     def get_company_statement(account_number:, month:, year:, company_rut: nil)

--- a/lib/bank_api/clients/banco_security/concerns/statements.rb
+++ b/lib/bank_api/clients/banco_security/concerns/statements.rb
@@ -1,0 +1,75 @@
+# coding: utf-8
+
+module BankApi::Clients::BancoSecurity
+  module Statements
+    DATE_CHARACTERS = (1..10)
+    DESCRIPTION_CHARACTERS = (11..60)
+    TRX_ID_CHARACTERS = (61..69)
+    TRX_TYPE_CHARACTER = 70
+    AMOUNT_CHARACTERS = (72..86)
+    BALANCE_CHARACTERS = (87..101)
+
+    def goto_account_statements
+      goto_frame query: '#leftFrame'
+      selenium_browser.execute_script(
+        "MM_goToURL(" +
+        "'parent.frames[\\'mainFrame\\']'," +
+        "'/empresas/cashmngfinal/cuenta_corriente/cuenta_historica_sel.asp?COD_SRV=1311'" +
+        ");"
+      )
+      goto_frame query: '#mainFrame'
+      wait(".Tit1:contains('cartola histórica')")
+    end
+
+    def select_statement(account_number, month, year)
+      select_account(account_number)
+      select_month(month, year)
+      browser.search("a > img[alt=\"Consultar\"]").click
+    end
+
+    def select_account(account_number)
+      formated_account_number = Utils::Account.format_account(account_number)
+      wait("select[name=\"Keyword\"]").set formated_account_number
+    rescue
+      raise StandardError, "Statement of given account doesn't exist"
+    end
+
+    def select_month(month, year)
+      wait("select[name=\"fecha\"]").set by_value: "#{month.to_s.rjust(2, '0')}#{year}"
+    rescue
+      raise StandardError, "Statement of given month and year doesn't exist"
+    end
+
+    def account_statement_from_txt
+      wait("div:contains('Cartolas disponibles')")
+      unless statement_available?
+        raise StandardError, "Statement of given month and account number is unavailable"
+      end
+      dl = browser.search("a")[1].download
+      dl.content.delete("\r").split("\n")[1..-2].map do |row|
+        parse_statement_movements(row.force_encoding("utf-8"))
+      end
+    end
+
+    def statement_available?
+      browser.search("b:contains('No existen movimientos para el periodo seleccionado')").none?
+    end
+
+    def parse_statement_movements(row)
+      {
+        date: Date.parse(row[DATE_CHARACTERS]),
+        description: row[DESCRIPTION_CHARACTERS].strip,
+        trx_id: row[TRX_ID_CHARACTERS].strip,
+        trx_type: statement_trx_type(row),
+        amount: row[AMOUNT_CHARACTERS].to_i,
+        balance: row[BALANCE_CHARACTERS].to_i
+      }
+    end
+
+    def statement_trx_type(row)
+      return :deposit if row[TRX_TYPE_CHARACTER] == "A"
+      return :charge if row[TRX_TYPE_CHARACTER] == "C"
+      raise StandardError, "Statement with trx of unknown type \"#{row[TRX_TYPE_CHARACTER]}\""
+    end
+  end
+end

--- a/lib/bank_api/clients/base_client.rb
+++ b/lib/bank_api/clients/base_client.rb
@@ -16,6 +16,11 @@ module BankApi::Clients
       parse_entries(get_deposits)
     end
 
+    def get_statement(account_number:, month:, year:, company_rut: nil)
+      validate_credentials
+      get_statement_of_month(account_number, month, year, company_rut)
+    end
+
     def transfer(transfer_data)
       validate_credentials
       validate_transfer_missing_data(transfer_data)
@@ -43,6 +48,10 @@ module BankApi::Clients
     end
 
     def get_deposits
+      raise NotImplementedError
+    end
+
+    def get_statement_of_month(_account_number, _month, _year, _company_rut)
       raise NotImplementedError
     end
 

--- a/lib/bank_api/clients/base_client.rb
+++ b/lib/bank_api/clients/base_client.rb
@@ -16,6 +16,11 @@ module BankApi::Clients
       parse_entries(get_deposits)
     end
 
+    def get_current_statement(account_number:, company_rut: nil)
+      validate_credentials
+      get_current_statement_of_account(account_number, company_rut)
+    end
+
     def get_statement(account_number:, month:, year:, company_rut: nil)
       validate_credentials
       get_statement_of_month(account_number, month, year, company_rut)
@@ -48,6 +53,10 @@ module BankApi::Clients
     end
 
     def get_deposits
+      raise NotImplementedError
+    end
+
+    def get_current_statement_of_account(_account_number, _company_rut)
       raise NotImplementedError
     end
 

--- a/lib/bank_api/clients/navigation/banco_security/company_navigation.rb
+++ b/lib/bank_api/clients/navigation/banco_security/company_navigation.rb
@@ -50,6 +50,32 @@ module BankApi::Clients::Navigation
         wait('a.k-link:contains("Recibidas")').click
       end
 
+      def goto_account_statements
+        goto_frame query: '#leftFrame'
+        selenium_browser.execute_script(
+          "MM_goToURL(" +
+          "'parent.frames[\\'mainFrame\\']'," +
+          "'/empresas/cashmngfinal/cuenta_corriente/cuenta_historica_sel.asp?COD_SRV=1311'" +
+          ");"
+        )
+        goto_frame query: '#mainFrame'
+        wait(".Tit1:contains('cartola histórica')")
+      end
+
+      def goto_current_statement
+        goto_frame query: '#leftFrame'
+        selenium_browser.execute_script(
+          "MM_goToURL(" +
+          "'parent.frames[\\'mainFrame\\']'," +
+          "'/empresas/RedirectConvivencia.asp?" +
+          "urlRedirect=Cartola/Home/CartolaOrSaldoCuentaCorriente'" +
+          ");"
+        )
+        goto_frame query: '#mainFrame'
+        goto_frame(query: 'iframe[name="central"]', should_reset: false)
+        wait("h1:contains('Cuenta Corriente')")
+      end
+
       def goto_transfer_form
         goto_frame query: '#topFrame'
         selenium_browser.execute_script(

--- a/lib/bank_api/utils/account.rb
+++ b/lib/bank_api/utils/account.rb
@@ -1,0 +1,9 @@
+module Utils
+  module Account
+    extend self
+
+    def format_account(number)
+      number.match(/0*([0-9]*)/)[1]
+    end
+  end
+end

--- a/lib/bank_api/utils/rut.rb
+++ b/lib/bank_api/utils/rut.rb
@@ -1,0 +1,9 @@
+module Utils
+  module Rut
+    extend self
+
+    def strip_rut(rut)
+      rut.tr(".-", "")
+    end
+  end
+end

--- a/spec/bank_api/clients/banco_security/concerns/statements_spec.rb
+++ b/spec/bank_api/clients/banco_security/concerns/statements_spec.rb
@@ -1,0 +1,195 @@
+require 'spec_helper'
+
+RSpec.describe BankApi::Clients::BancoSecurity::Statements do
+  let(:browser) { double(config: { wait_timeout: 0.5, wait_interval: 0.1 }) }
+  let(:selenium_browser) { double }
+  let(:div) { double(text: 'text', none?: true) }
+  let(:input) { double }
+  let(:dynamic_card) { double }
+  let(:account_number) { "000012345678" }
+  let(:month) { 1 }
+  let(:year) { 2018 }
+
+  class DummyClass < BankApi::Clients::BaseClient
+    include BankApi::Clients::BancoSecurity::Statements
+
+    def initialize
+      @user_rut = '12.345.678-9'
+      @password = 'password'
+      @company_rut = '98.765.432-1'
+      @days_to_check = 6
+      @page_size = 30
+    end
+  end
+
+  let(:dummy) { DummyClass.new }
+
+  let(:txt_file) do
+    double(
+      content: "" +
+        "1234567891234                 PESOS0000401/01/201801/01/201801/01/2018      1000000,00  " +
+        "                          JUAN PEREZ PEREZ+            0,00             0,00        \r\n" +
+        "202/01/2018TRANSFERENCIA DESDE BANCO SECURITY DE JUANA PEREZ 000000001A+        1000,00 " +
+        "    1001000,00                                                                      \r\n" +
+        "203/01/2018TRANSFERENCIA DESDE BANCO FALABELLA DE JUAN PEREZ 000000002C+        2000,00 " +
+        "     999000,00                                                                      \r\n" +
+        "9+      1000000,00     1234567,00     1234567,00       123456,00                          "
+    )
+  end
+
+  let(:download_link) { double }
+
+  def mock_browser
+    allow(dummy).to receive(:browser).and_return(browser)
+    allow(dummy).to receive(:goto_frame)
+    allow(browser).to receive(:search).and_return(div)
+    allow(browser).to receive(:search).with('a').and_return([double, download_link, double])
+  end
+
+  def mock_div
+    allow(download_link).to receive(:download).and_return(txt_file)
+    allow(input).to receive(:set)
+    allow(div).to receive(:none?).and_return(true)
+    allow(div).to receive(:click)
+    allow(div).to receive(:set)
+  end
+
+  def mock_selenium_browser
+    allow(dummy).to receive(:selenium_browser).and_return(selenium_browser)
+    allow(selenium_browser).to receive(:execute_script)
+  end
+
+  def mock_wait
+    allow(dummy).to receive(:wait).and_return(div)
+    allow(dummy).to receive(:wait).with("select[name=\"Keyword\"]").and_return(input)
+    allow(dummy).to receive(:wait).with("select[name=\"fecha\"]").and_return(input)
+  end
+
+  before do
+    dummy.instance_variable_set(:@dynamic_card, dynamic_card)
+    allow(dummy).to receive(:statement_available?).and_return(true)
+    mock_browser
+    mock_selenium_browser
+    mock_div
+    mock_wait
+  end
+
+  describe "#go_to_account_statements" do
+    it "implements goto_account_statements" do
+      expect { dummy.goto_account_statements }.not_to raise_error
+    end
+  end
+
+  describe "#select_account" do
+    it "sets the account number" do
+      expect(input).to receive(:set).with("12345678")
+      dummy.select_account(account_number)
+    end
+
+    context "without account" do
+      before do
+        allow(input).to receive(:set).with("12345678").and_raise(
+          StandardError, "Timeout"
+        )
+      end
+
+      it "raises error" do
+        expect { dummy.select_account(account_number) }.to raise_error(
+          StandardError, "Statement of given account doesn't exist"
+        )
+      end
+    end
+  end
+
+  describe "#select_month" do
+    it "sets the month" do
+      expect(input).to receive(:set).with(by_value: "012018")
+      dummy.select_month(month, year)
+    end
+
+    context "without month statement" do
+      before do
+        allow(input).to receive(:set).with(by_value: "012018").and_raise(
+          StandardError, "Timeout"
+        )
+      end
+
+      it "raises error" do
+        expect { dummy.select_month(month, year) }.to raise_error(
+          StandardError, "Statement of given month and year doesn't exist"
+        )
+      end
+    end
+  end
+
+  describe "#select_statement" do
+    it "doesn't raise_error" do
+      expect { dummy.select_statement(account_number, month, year) }.not_to raise_error
+    end
+
+    it "sets the account number and month" do
+      expect(input).to receive(:set).with("12345678")
+      expect(input).to receive(:set).with(by_value: "012018")
+      dummy.select_statement(account_number, month, year)
+    end
+  end
+
+  describe "#account_statement_from_txt" do
+    it "doesn't raise_error" do
+      expect { dummy.account_statement_from_txt }.not_to raise_error
+    end
+
+    it "returns expected statement" do
+      expect(dummy.account_statement_from_txt).to eq(
+        [
+          {
+            date: Date.new(2018, 1, 2),
+            description: "TRANSFERENCIA DESDE BANCO SECURITY DE JUANA PEREZ",
+            trx_id: "000000001",
+            trx_type: :deposit,
+            amount: 1000,
+            balance: 1001000
+          }, {
+            date: Date.new(2018, 1, 3),
+            description: "TRANSFERENCIA DESDE BANCO FALABELLA DE JUAN PEREZ",
+            trx_id: "000000002",
+            trx_type: :charge,
+            amount: 2000,
+            balance: 999000
+          }
+        ]
+      )
+    end
+
+    context "without statement" do
+      before do
+        allow(dummy).to receive(:statement_available?).and_return(false)
+      end
+
+      it "raises error" do
+        expect { dummy.account_statement_from_txt }.to raise_error(
+          StandardError, "Statement of given month and account number is unavailable"
+        )
+      end
+    end
+
+    context "with unknown trx_type" do
+      let(:txt_file) do
+        double(
+          content: "" +
+            "1234567891234                 PESOS0000401/01/201801/01/201801/01/2018      1000000" +
+            ",00                            JUAN PEREZ PEREZ+            0,00             0,00\n" +
+            "202/01/2018TRANSFERENCIA DESDE BANCO SECURITY DE JUANA PEREZ 000000001X+        1000" +
+            ",00     1001000,00                                                              \r\n" +
+            "9+      1000000,00     1234567,00     1234567,00       123456,00                      "
+        )
+      end
+
+      it "raises error" do
+        expect { dummy.account_statement_from_txt }.to raise_error(
+          StandardError, "Statement with trx of unknown type \"X\""
+        )
+      end
+    end
+  end
+end

--- a/spec/bank_api/clients/banco_security/concerns/statements_spec.rb
+++ b/spec/bank_api/clients/banco_security/concerns/statements_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe BankApi::Clients::BancoSecurity::Statements do
 
   class DummyClass < BankApi::Clients::BaseClient
     include BankApi::Clients::BancoSecurity::Statements
+    include BankApi::Clients::Navigation
 
     def initialize
       @user_rut = '12.345.678-9'
@@ -24,26 +25,13 @@ RSpec.describe BankApi::Clients::BancoSecurity::Statements do
 
   let(:dummy) { DummyClass.new }
 
-  let(:txt_file) do
-    double(
-      content: "" +
-        "1234567891234                 PESOS0000401/01/201801/01/201801/01/2018      1000000,00  " +
-        "                          JUAN PEREZ PEREZ+            0,00             0,00        \r\n" +
-        "202/01/2018TRANSFERENCIA DESDE BANCO SECURITY DE JUANA PEREZ 000000001A+        1000,00 " +
-        "    1001000,00                                                                      \r\n" +
-        "203/01/2018TRANSFERENCIA DESDE BANCO FALABELLA DE JUAN PEREZ 000000002C+        2000,00 " +
-        "     999000,00                                                                      \r\n" +
-        "9+      1000000,00     1234567,00     1234567,00       123456,00                          "
-    )
-  end
-
   let(:download_link) { double }
 
   def mock_browser
     allow(dummy).to receive(:browser).and_return(browser)
+    allow(dummy).to receive(:goto)
     allow(dummy).to receive(:goto_frame)
     allow(browser).to receive(:search).and_return(div)
-    allow(browser).to receive(:search).with('a').and_return([double, download_link, double])
   end
 
   def mock_div
@@ -61,8 +49,6 @@ RSpec.describe BankApi::Clients::BancoSecurity::Statements do
 
   def mock_wait
     allow(dummy).to receive(:wait).and_return(div)
-    allow(dummy).to receive(:wait).with("select[name=\"Keyword\"]").and_return(input)
-    allow(dummy).to receive(:wait).with("select[name=\"fecha\"]").and_return(input)
   end
 
   before do
@@ -74,121 +60,266 @@ RSpec.describe BankApi::Clients::BancoSecurity::Statements do
     mock_wait
   end
 
-  describe "#go_to_account_statements" do
-    it "implements goto_account_statements" do
-      expect { dummy.goto_account_statements }.not_to raise_error
-    end
-  end
-
-  describe "#select_account" do
-    it "sets the account number" do
-      expect(input).to receive(:set).with("12345678")
-      dummy.select_account(account_number)
-    end
-
-    context "without account" do
-      before do
-        allow(input).to receive(:set).with("12345678").and_raise(
-          StandardError, "Timeout"
-        )
-      end
-
-      it "raises error" do
-        expect { dummy.select_account(account_number) }.to raise_error(
-          StandardError, "Statement of given account doesn't exist"
-        )
-      end
-    end
-  end
-
-  describe "#select_month" do
-    it "sets the month" do
-      expect(input).to receive(:set).with(by_value: "012018")
-      dummy.select_month(month, year)
-    end
-
-    context "without month statement" do
-      before do
-        allow(input).to receive(:set).with(by_value: "012018").and_raise(
-          StandardError, "Timeout"
-        )
-      end
-
-      it "raises error" do
-        expect { dummy.select_month(month, year) }.to raise_error(
-          StandardError, "Statement of given month and year doesn't exist"
-        )
-      end
-    end
-  end
-
-  describe "#select_statement" do
-    it "doesn't raise_error" do
-      expect { dummy.select_statement(account_number, month, year) }.not_to raise_error
-    end
-
-    it "sets the account number and month" do
-      expect(input).to receive(:set).with("12345678")
-      expect(input).to receive(:set).with(by_value: "012018")
-      dummy.select_statement(account_number, month, year)
-    end
-  end
-
-  describe "#account_statement_from_txt" do
-    it "doesn't raise_error" do
-      expect { dummy.account_statement_from_txt }.not_to raise_error
-    end
-
-    it "returns expected statement" do
-      expect(dummy.account_statement_from_txt).to eq(
-        [
-          {
-            date: Date.new(2018, 1, 2),
-            description: "TRANSFERENCIA DESDE BANCO SECURITY DE JUANA PEREZ",
-            trx_id: "000000001",
-            trx_type: :deposit,
-            amount: 1000,
-            balance: 1001000
-          }, {
-            date: Date.new(2018, 1, 3),
-            description: "TRANSFERENCIA DESDE BANCO FALABELLA DE JUAN PEREZ",
-            trx_id: "000000002",
-            trx_type: :charge,
-            amount: 2000,
-            balance: 999000
-          }
-        ]
+  describe "current_statement" do
+    let(:txt_file) do
+      double(
+        content: "" +
+          "Nombre;Dirección;Comuna;...\r\n" +
+          "FINTUAL ADMINISTRADORA GENERAL DE FONDOS S A...\r\n" +
+          "Fecha;Descripción;N de documento;Cargos;Abonos;Saldo\r\n" +
+          "01/01;Transferencia  ; 0000000001;0.00;500,000.00;10,000,000.00\r\n" +
+          "02/01;Transferencia  ; 0000000002;500,000.00;0.00;9,500,000.00\r\n" +
+          "01/01;SALDO INICIAL;;0.00;0.00;10,000,000.00\r\n" +
+          "Resumen del período\r\n" +
+          "Saldo inicial;Total cargos;Total abonos;Saldo final\r\n" +
+          "10,000,000.00;10,000,000.00;10,000,000.00;10,000,000.00\r\n" +
+          "Cheques pagados\r\n" +
+          " \r\n" +
+          "Cheques devueltos\r\n" +
+          " \r\n"
       )
     end
 
-    context "without statement" do
+    before do
+      allow(browser).to receive(:search)
+        .with("a:contains('Descargar TXT')").and_return(download_link)
+    end
+
+    describe "#select_current_statement" do
+      let(:accounts_table) { double(any?: false) }
+
       before do
-        allow(dummy).to receive(:statement_available?).and_return(false)
+        allow(browser).to receive(:search)
+          .with(".cuentas-corrientes").and_return(accounts_table)
+        allow(div).to receive(:attribute).with("data-numero-cuenta").and_return("12345678")
       end
 
-      it "raises error" do
-        expect { dummy.account_statement_from_txt }.to raise_error(
-          StandardError, "Statement of given month and account number is unavailable"
-        )
+      it "doesn't raise error" do
+        expect { dummy.select_current_statement(account_number) }.not_to raise_error
+      end
+
+      context "with wrong account" do
+        before do
+          allow(div).to receive(:attribute).with("data-numero-cuenta").and_return("wrong_number")
+        end
+
+        it "raises error" do
+          expect { dummy.select_current_statement(account_number) }.to raise_error(
+            StandardError, "Statement of given account number is unavailable"
+          )
+        end
+      end
+
+      context "with multiple accounts" do
+        let(:accounts_table) { double(any?: true) }
+        let(:links) do
+          [
+            double(text: "wrong_account"),
+            double(text: "12345678"),
+            double(text: "wrong_account")
+          ]
+        end
+
+        before do
+          allow(links[1]).to receive(:click)
+          allow(accounts_table).to receive(:map).and_return(links)
+        end
+
+        it "doesn't raise error" do
+          expect { dummy.select_current_statement(account_number) }.not_to raise_error
+        end
+
+        context "with account missing in table" do
+          let(:links) do
+            [
+              double(text: "wrong_account"),
+              double(text: "wrong_account"),
+              double(text: "wrong_account")
+            ]
+          end
+
+          it "raises error" do
+            expect { dummy.select_current_statement(account_number) }.to raise_error(
+              StandardError, "Statement of given account number is unavailable"
+            )
+          end
+        end
       end
     end
 
-    context "with unknown trx_type" do
-      let(:txt_file) do
-        double(
-          content: "" +
+    describe "#account_current_statement_from_txt" do
+      it "doesn't raise error" do
+        expect { dummy.account_current_statement_from_txt }.not_to raise_error
+      end
+
+      it "returns expected statement" do
+        expect(dummy.account_current_statement_from_txt).to eq(
+          [
+            {
+              date: Date.new(2018, 1, 1),
+              description: "Transferencia",
+              trx_id: "0000000001",
+              trx_type: :deposit,
+              amount: 500_000,
+              balance: 10_000_000
+            }, {
+              date: Date.new(2018, 1, 2),
+              description: "Transferencia",
+              trx_id: "0000000002",
+              trx_type: :charge,
+              amount: 500_000,
+              balance: 9_500_000
+            }
+          ]
+        )
+      end
+
+      context "with timeout when searching for download link" do
+        before do
+          allow(browser).to receive(:search).with("a:contains('Descargar TXT')").and_raise(
+            StandardError, "Timeout"
+          )
+        end
+
+        it "raises error" do
+          expect { dummy.account_current_statement_from_txt }.to raise_error(
+            StandardError, "Statement of given account number is unavailable"
+          )
+        end
+      end
+    end
+  end
+
+  describe "statements" do
+    let(:txt_file) do
+      double(
+        content: "" +
+          "1234567891234                 PESOS0000401/01/201801/01/201801/01/2018      1000000,00" +
+          "                          JUAN PEREZ PEREZ+            0,00             0,00      \r\n" +
+          "202/01/2018TRANSFERENCIA DESDE BANCO SECURITY DE JUANA PEREZ 000000001A+        1000" +
+          ",00     1001000,00                                                                \r\n" +
+          "203/01/2018TRANSFERENCIA DESDE BANCO FALABELLA DE JUAN PEREZ 000000002C+        2000" +
+          ",00      999000,00                                                                \r\n" +
+          "9+      1000000,00     1234567,00     1234567,00       123456,00                        "
+      )
+    end
+
+    before do
+      allow(dummy).to receive(:wait).with("select[name=\"Keyword\"]").and_return(input)
+      allow(dummy).to receive(:wait).with("select[name=\"fecha\"]").and_return(input)
+      allow(browser).to receive(:search).with('a').and_return([double, download_link, double])
+    end
+
+    describe "#select_account" do
+      it "sets the account number" do
+        expect(input).to receive(:set).with("12345678")
+        dummy.select_account(account_number)
+      end
+
+      context "without account" do
+        before do
+          allow(input).to receive(:set).with("12345678").and_raise(
+            StandardError, "Timeout"
+          )
+        end
+
+        it "raises error" do
+          expect { dummy.select_account(account_number) }.to raise_error(
+            StandardError, "Statement of given account number is unavailable"
+          )
+        end
+      end
+    end
+
+    describe "#select_month" do
+      it "sets the month" do
+        expect(input).to receive(:set).with(by_value: "012018")
+        dummy.select_month(month, year)
+      end
+
+      context "without month statement" do
+        before do
+          allow(input).to receive(:set).with(by_value: "012018").and_raise(
+            StandardError, "Timeout"
+          )
+        end
+
+        it "raises error" do
+          expect { dummy.select_month(month, year) }.to raise_error(
+            StandardError, "Statement of given month and year is unavailable"
+          )
+        end
+      end
+    end
+
+    describe "#select_statement" do
+      it "doesn't raise_error" do
+        expect { dummy.select_statement(account_number, month, year) }.not_to raise_error
+      end
+
+      it "sets the account number and month" do
+        expect(input).to receive(:set).with("12345678")
+        expect(input).to receive(:set).with(by_value: "012018")
+        dummy.select_statement(account_number, month, year)
+      end
+    end
+
+    describe "#account_statement_from_txt" do
+      it "doesn't raise_error" do
+        expect { dummy.account_statement_from_txt }.not_to raise_error
+      end
+
+      it "returns expected statement" do
+        expect(dummy.account_statement_from_txt).to eq(
+          [
+            {
+              date: Date.new(2018, 1, 2),
+              description: "TRANSFERENCIA DESDE BANCO SECURITY DE JUANA PEREZ",
+              trx_id: "000000001",
+              trx_type: :deposit,
+              amount: 1000,
+              balance: 1001000
+            }, {
+              date: Date.new(2018, 1, 3),
+              description: "TRANSFERENCIA DESDE BANCO FALABELLA DE JUAN PEREZ",
+              trx_id: "000000002",
+              trx_type: :charge,
+              amount: 2000,
+              balance: 999000
+            }
+          ]
+        )
+      end
+
+      context "without statement" do
+        before do
+          allow(dummy).to receive(:statement_available?).and_return(false)
+        end
+
+        it "raises error" do
+          expect { dummy.account_statement_from_txt }.to raise_error(
+            StandardError, "Statement of given month and account number is unavailable"
+          )
+        end
+      end
+
+      context "with unknown trx_type" do
+        let(:txt_file) do
+          double(
+            content: "" +
             "1234567891234                 PESOS0000401/01/201801/01/201801/01/2018      1000000" +
             ",00                            JUAN PEREZ PEREZ+            0,00             0,00\n" +
             "202/01/2018TRANSFERENCIA DESDE BANCO SECURITY DE JUANA PEREZ 000000001X+        1000" +
             ",00     1001000,00                                                              \r\n" +
             "9+      1000000,00     1234567,00     1234567,00       123456,00                      "
-        )
-      end
+          )
+        end
 
-      it "raises error" do
-        expect { dummy.account_statement_from_txt }.to raise_error(
-          StandardError, "Statement with trx of unknown type \"X\""
-        )
+        it "raises error" do
+          expect { dummy.account_statement_from_txt }.to raise_error(
+            StandardError, "Statement with trx of unknown type \"X\""
+          )
+        end
       end
     end
   end

--- a/spec/bank_api/clients/base_client_spec.rb
+++ b/spec/bank_api/clients/base_client_spec.rb
@@ -64,6 +64,28 @@ RSpec.describe BankApi::Clients::BaseClient do
     end
   end
 
+  describe "#get_current_statement" do
+    let(:account_number) { "000012345678" }
+    let(:company_rut) { "12.345.678-9" }
+
+    it "validates credentials and returns statement" do
+      expect(subject).to receive(:validate_credentials)
+      expect(subject).to receive(:get_current_statement_of_account)
+      subject.get_current_statement(account_number: account_number, company_rut: company_rut)
+    end
+  end
+
+  describe "#get_statement_of_account" do
+    let(:account_number) { "000012345678" }
+    let(:company_rut) { "12.345.678-9" }
+
+    it "raises error" do
+      expect do
+        subject.send(:get_current_statement_of_account, account_number, company_rut)
+      end.to raise_error(NotImplementedError)
+    end
+  end
+
   describe "#get_statement" do
     let(:account_number) { "000012345678" }
     let(:company_rut) { "12.345.678-9" }

--- a/spec/bank_api/clients/base_client_spec.rb
+++ b/spec/bank_api/clients/base_client_spec.rb
@@ -64,6 +64,34 @@ RSpec.describe BankApi::Clients::BaseClient do
     end
   end
 
+  describe "#get_statement" do
+    let(:account_number) { "000012345678" }
+    let(:company_rut) { "12.345.678-9" }
+    let(:month) { 1 }
+    let(:year) { 2018 }
+
+    it "validates credentials and returns statement" do
+      expect(subject).to receive(:validate_credentials)
+      expect(subject).to receive(:get_statement_of_month)
+      subject.get_statement(
+        account_number: account_number, month: month, year: year, company_rut: company_rut
+      )
+    end
+  end
+
+  describe "#get_statement_of_month" do
+    let(:account_number) { "000012345678" }
+    let(:company_rut) { "12.345.678-9" }
+    let(:month) { 1 }
+    let(:year) { 2018 }
+
+    it "raises error" do
+      expect do
+        subject.send(:get_statement_of_month, account_number, month, year, company_rut)
+      end.to raise_error(NotImplementedError)
+    end
+  end
+
   describe "#transfer" do
     before do
       mock_validate_credentials

--- a/spec/bank_api/utils/account_spec.rb
+++ b/spec/bank_api/utils/account_spec.rb
@@ -1,0 +1,14 @@
+require 'date'
+require 'spec_helper'
+
+RSpec.describe Utils::Account do
+  describe "#format_account" do
+    it "removes first zeroes" do
+      expect(described_class.format_account("0000123456789")).to eq("123456789")
+    end
+
+    it "keeps account number if there's no padding zeroes" do
+      expect(described_class.format_account("123456789")).to eq("123456789")
+    end
+  end
+end

--- a/spec/bank_api/utils/rut_spec.rb
+++ b/spec/bank_api/utils/rut_spec.rb
@@ -1,0 +1,13 @@
+require 'date'
+require 'spec_helper'
+
+RSpec.describe Utils::Rut do
+  describe "#strip_rut" do
+    let(:rut) { "12.345.678-9" }
+    let(:expected_rut) { "123456789" }
+
+    it "returns expected rut" do
+      expect(described_class.strip_rut(rut)).to eq(expected_rut)
+    end
+  end
+end

--- a/spec/bank_api_spec.rb
+++ b/spec/bank_api_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe BankApi do
     BankApi::BancoSecurity.get_recent_company_deposits
   end
 
+  it 'calls get_statement on BancoSecurity::CompanyClient' do
+    expect_any_instance_of(BankApi::Clients::BancoSecurity::CompanyClient)
+      .to receive(:get_statement)
+
+    BankApi::BancoSecurity.get_company_statement(
+      account_number: "000012345678",
+      company_rut: "12.345.678-9",
+      month: 1,
+      year: 2018
+    )
+  end
+
   it 'calls transfer on  BancoSecurity::CompanyClient' do
     expect_any_instance_of(BankApi::Clients::BancoSecurity::CompanyClient)
       .to receive(:transfer)


### PR DESCRIPTION
# Cambios
- Ahora se pueden descargar las cartolas de una cuenta en el banco security.

```
BankApi::BancoSecurity.get_company_statement(
  account_number: "0000012345", month: 1, year: 2018, company_rut: "12.456.789-K"
)
=> 
[
  {
    date: Date.new(2018, 1, 2),
    description: "TRANSFERENCIA DESDE BANCO SECURITY DE JUANA PEREZ",
    trx_id: "000000001",
    trx_type: :deposit,
    amount: 1000,
    balance: 1001000
  }, {
    date: Date.new(2018, 1, 3),
    description: "TRANSFERENCIA DESDE BANCO FALABELLA DE JUAN PEREZ",
    trx_id: "000000002",
    trx_type: :charge,
    amount: 2000,
    balance: 999000
  }
]
```
- También se puede descargar la cartola actual:

```
[
  {
    date: Date.new(2018, 1, 1),
    description: "Transferencia",
    trx_id: "0000000001",
    trx_type: :deposit,
    amount: 500_000,
    balance: 10_000_000
  }, {
    date: Date.new(2018, 1, 2),
    description: "Transferencia",
    trx_id: "0000000002",
    trx_type: :charge,
    amount: 500_000,
    balance: 9_500_000
  }
]
```