### PR TITLE
feat(security): extract deposits from account details too

### DIFF
--- a/lib/bank_api.rb
+++ b/lib/bank_api.rb
@@ -27,20 +27,23 @@ module BankApi
 
   module BancoSecurity
     def self.get_account_balance(account_number)
-      Clients::BancoSecurity::CompanyClient.new(BankApi.configuration).get_balance(account_number)
+      company_instance.get_balance(account_number)
     end
 
-    def self.get_recent_company_deposits
-      Clients::BancoSecurity::CompanyClient.new(BankApi.configuration).get_recent_deposits
+    def self.get_recent_company_deposits(options = {})
+      company_instance.get_recent_deposits(options)
     end
 
     def self.company_transfer(transfer_data)
-      Clients::BancoSecurity::CompanyClient.new(BankApi.configuration).transfer(transfer_data)
+      company_instance.transfer(transfer_data)
     end
 
     def self.company_batch_transfers(transfers_data)
+      company_instance.batch_transfers(transfers_data)
+    end
+
+    def self.company_instance
       Clients::BancoSecurity::CompanyClient.new(BankApi.configuration)
-                                           .batch_transfers(transfers_data)
     end
   end
 end

--- a/lib/bank_api/clients/banco_de_chile_company_client.rb
+++ b/lib/bank_api/clients/banco_de_chile_company_client.rb
@@ -37,7 +37,7 @@ module BankApi::Clients
       ].any?(&:nil?)
     end
 
-    def get_deposits
+    def get_deposits(_options = {})
       login
       goto_deposits
       select_deposits_range

--- a/lib/bank_api/clients/banco_security/company_client.rb
+++ b/lib/bank_api/clients/banco_security/company_client.rb
@@ -37,14 +37,15 @@ module BankApi::Clients::BancoSecurity
       find_account_balance(account_number)
     end
 
-    def get_deposits
+    def get_deposits(options = {})
       login
       goto_company_dashboard
-      goto_deposits
-      select_deposits_range
-      deposits = deposits_from_txt
-      validate_deposits(deposits) unless deposits.empty?
-      deposits
+
+      if options[:source] == :account_details
+        return get_deposits_from_balance_section(options[:account_number])
+      end
+
+      get_deposits_from_transfers_section
     ensure
       browser.close
     end
@@ -69,6 +70,21 @@ module BankApi::Clients::BancoSecurity
       end
     ensure
       browser.close
+    end
+
+    def get_deposits_from_transfers_section
+      goto_deposits
+      select_deposits_range
+      deposits = deposits_from_txt
+      validate_deposits(deposits) unless deposits.empty?
+      deposits
+    end
+
+    def get_deposits_from_balance_section(account_number)
+      fail "missing :account_number option" unless account_number
+      goto_balance
+      goto_account_details(account_number.to_s)
+      deposits_from_account_details
     end
 
     def goto_frame(query: nil, should_reset: true)

--- a/lib/bank_api/clients/base_client.rb
+++ b/lib/bank_api/clients/base_client.rb
@@ -11,9 +11,9 @@ module BankApi::Clients
       @days_to_check = config.days_to_check
     end
 
-    def get_recent_deposits
+    def get_recent_deposits(options = {})
       validate_credentials
-      parse_entries(get_deposits)
+      parse_entries(get_deposits(options))
     end
 
     def transfer(transfer_data)
@@ -42,7 +42,7 @@ module BankApi::Clients
       raise NotImplementedError
     end
 
-    def get_deposits
+    def get_deposits(_options = {})
       raise NotImplementedError
     end
 
@@ -122,8 +122,10 @@ module BankApi::Clients
         BankApi::Values::DepositEntry.new(
           entry[:amount],
           entry[:date],
+          entry[:time],
           entry[:rut],
-          bank_name
+          bank_name,
+          entry[:client]
         )
       end
       BankApi::SignDeposits.sign(deposit_entries)

--- a/lib/bank_api/clients/navigation/banco_security/company_navigation.rb
+++ b/lib/bank_api/clients/navigation/banco_security/company_navigation.rb
@@ -67,6 +67,10 @@ module BankApi::Clients::Navigation
         goto_frame query: 'iframe[name="central"]', should_reset: false
       end
 
+      def goto_account_details(account_number)
+        wait("a.clickable:contains(\"#{account_number}\")").click
+      end
+
       def goto_transfer_form
         goto_frame query: '#topFrame'
         selenium_browser.execute_script(

--- a/lib/bank_api/sign_deposits.rb
+++ b/lib/bank_api/sign_deposits.rb
@@ -37,6 +37,7 @@ module BankApi::SignDeposits
   end
 
   def entry_key(entry)
-    "#{entry.amount}|#{entry.date}|#{entry.rut}|#{entry.bank}"
+    rut_or_client = entry.rut || entry.client.to_s.downcase.delete(' ')
+    "#{entry.amount}|#{entry.date}|#{rut_or_client}|#{entry.bank}"
   end
 end

--- a/lib/bank_api/values/deposit_entry.rb
+++ b/lib/bank_api/values/deposit_entry.rb
@@ -1,12 +1,14 @@
 module BankApi::Values
   class DepositEntry
-    attr_accessor :amount, :date, :rut, :signature, :bank
+    attr_accessor :client, :amount, :date, :time, :rut, :signature, :bank
 
-    def initialize(amount, date, rut, bank)
+    def initialize(amount, date, time, rut, bank, client)
       @amount = amount
       @date = date
+      @time = time
       @rut = rut
       @bank = bank
+      @client = client
     end
   end
 end

--- a/spec/bank_api/clients/banco_security/concerns/deposits_spec.rb
+++ b/spec/bank_api/clients/banco_security/concerns/deposits_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe BankApi::Clients::BancoSecurity::Deposits do
     dummy.instance_variable_set(:@dynamic_card, dynamic_card)
     allow(dummy).to receive(:browser).and_return(browser)
     allow(dummy).to receive(:deposits_txt_url).and_return(txt_url)
+    allow(dummy).to receive(:deposits_account_details_url).and_return(txt_url)
     allow(dummy).to receive(:any_deposits?).and_return(true)
 
     allow(browser).to receive(:search).and_return(div)
@@ -79,24 +80,70 @@ RSpec.describe BankApi::Clients::BancoSecurity::Deposits do
       expect(dummy.deposits_from_txt).to eq(
         [
           {
+            client: "PEPE",
             rut: '12.345.678-9',
             date: Date.parse('01/01/2018'),
+            time: DateTime.parse('01/01/2018 1:15'),
             amount: 1000
           },
           {
+            client: "GARY",
             rut: '12.345.678-9',
             date: Date.parse('01/01/2018'),
+            time: DateTime.parse('01/01/2018 5:15'),
             amount: 2000
           },
           {
+            client: "PEPE",
             rut: '12.345.678-9',
             date: Date.parse('01/01/2018'),
+            time: DateTime.parse('01/01/2018 7:15'),
             amount: 3000
           },
           {
+            client: "PEPE",
             rut: '12.345.678-9',
             date: Date.parse('02/01/2018'),
+            time: DateTime.parse('01/01/2018 21:00'),
             amount: 4000
+          }
+        ]
+      )
+    end
+  end
+
+  context "with deposits from account details" do
+    let(:txt_file) do
+      content = <<~DOC
+        Nombre;Direcci\xF3n;Comuna;Ciudad;Cuenta;Moneda;Cartola;Desde;Hasta;Fecha cartola anterior;Saldo final cartola anterior;Ejecutivo;Oficina;Tel\xE9fono;L\xEDnea de Cr\xE9dito Monto utilizado;L\xEDnea de Cr\xE9dito Monto Disponible;Vencimiento\r\LEANS ADMINISTRADORA GENERAL DE FONDOS S A;LOS CONQUISTADORES 111, PROVIDENCIA, SANTIAGO;PROVIDENCIA;SANTIAGO;666698607;CLP;Provisoria;666666;7777777;Fecha cartola anterior en duro;;LEAN SEGOVIA;EL GOLF;2342342234;0;0.0;4334334\r\nFecha;Descripci\xF3n;N de documento;Cargos;Abonos;Saldo\r\n12/09;TRANSFERENCIA DESDE Banco Santander De ALICIA FORTUNATO ; 00056290667;0.00;180,000.00;47,300,662.00\r\n12/09;TRANSFERENCIA DESDE Banco Santander De SANDRA VILLANUEVA; 00056290549;0.00;2,230,000.00;47,120,662.00\r\n12/09;TRANSFERENCIA DESDE BANCO SECURITY DE LEANDRO SEGOVIA ; 00056290121;0.00;300,000.00;44,890,662.00\r\n12/09;TRANSFERENCIA A Banco Santander PARA Mario Ruiz Tagle; 00056288530;199,073.00;0.00;44,590,662.00\r\n12/09;TRANSFERENCIA A BCI PARA Juan Bustos Cavada ; 00056288222;4,150,374.00;0.00;44,789,735.00\r\n12/09;TRANSFERENCIA A Banco Chile-Edwards-Citi PARA Javier Andr s Soto  ; 00056288091;92,000.00;0.00;48,940,109.00\r\n12/09;TRANSFERENCIA A Banco Santander PARA Sebastian Ortega; 00056287857;2,231,196.00;0.00;49,032,109.00\r\n03/09;TRANSFERENCIA DESDE BBVA De SILVA DAURO ; 00054935695;0.00;50,000.00;93,342,708.00\r\n03/09;SALDO INICIAL;;0.00;0.00;93,292,708.00\r\nResumen del per\xEDodo\r\nSaldo inicial;Total cargos;Total abonos;Saldo final\r\n93,292,708.00;696,761,603.00;650,769,557.00;93,292,708.00\r\nCheques pagados\r\n;;;;;\r\nCheques devueltos\r\n;;;;;\r\n
+      DOC
+
+      double(content: content)
+    end
+
+    it "returns deposits" do
+      expect(dummy.deposits_from_account_details).to eq(
+        [
+          {
+            client: "SILVA DAURO",
+            rut: nil,
+            date: Date.parse('03/09/2018'),
+            time: nil,
+            amount: 50000
+          },
+          {
+            client: "LEANDRO SEGOVIA",
+            rut: nil,
+            date: Date.parse('12/09/2018'),
+            time: nil,
+            amount: 300000
+          },
+          {
+            client: "SANDRA VILLANUEVA",
+            rut: nil,
+            date: Date.parse('12/09/2018'),
+            time: nil,
+            amount: 2230000
           }
         ]
       )

--- a/spec/bank_api/sign_deposits_spec.rb
+++ b/spec/bank_api/sign_deposits_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe BankApi::SignDeposits do
   let(:entries) do
     [
       BankApi::Values::DepositEntry.new(
-        25000, Date.new(2017, 3, 3), '12345678-9', :security
+        25000, Date.new(2017, 3, 3), nil, '12345678-9', :security, "Lean"
       )
     ]
   end
@@ -24,7 +24,7 @@ RSpec.describe BankApi::SignDeposits do
   context 'with entries with same data' do
     before do
       entries << BankApi::Values::DepositEntry.new(
-        25000, Date.new(2017, 3, 3), '12345678-9', :security
+        25000, Date.new(2017, 3, 3), nil, '12345678-9', :security, "Lean"
       )
     end
 
@@ -32,6 +32,17 @@ RSpec.describe BankApi::SignDeposits do
       BankApi::SignDeposits.sign(entries)
       expect(entries[0].signature).to eq(expected_signature)
       expect(entries[1].signature).not_to eq(expected_signature)
+    end
+  end
+
+  context 'when entry has nil rut' do
+    let(:expected_signature) { '25000|2017-03-03|lean|security|1' }
+
+    before { entries.first.rut = nil }
+
+    it 'calculates different signature' do
+      BankApi::SignDeposits.sign(entries)
+      expect(entries[0].signature).to eq(expected_signature)
     end
   end
 end


### PR DESCRIPTION
Tengo que pasar los parámetros así: `BankApi::BancoSecurity.get_recent_company_deposits(source: :account_details, account_number: "xxx")` para obtener los depósitos desde la cartola.

`BankApi::BancoSecurity.get_recent_company_deposits` Así sigue funcionando para descargar como ya lo estabas haciendo.

La idea es desde fintual usar las dos colecciones para ver que coincidan.