### PR TITLE
feat(security): extract balances without account number

### DIFF
--- a/lib/bank_api.rb
+++ b/lib/bank_api.rb
@@ -25,13 +25,13 @@ module BankApi
     Clients::BancoDeChileCompanyClient.new(configuration).get_recent_deposits(options)
   end
 
-  def self.get_bdc_account_balance(account_number)
-    Clients::BancoDeChileCompanyClient.new(configuration).get_account_balance(account_number)
+  def self.get_bdc_account_balance(options = {})
+    Clients::BancoDeChileCompanyClient.new(configuration).get_account_balance(options)
   end
 
   module BancoSecurity
-    def self.get_account_balance(account_number)
-      company_instance.get_balance(account_number)
+    def self.get_account_balance(options = {})
+      company_instance.get_balance(options)
     end
 
     def self.get_recent_company_deposits(options = {})

--- a/lib/bank_api/clients/banco_de_chile_company_client.rb
+++ b/lib/bank_api/clients/banco_de_chile_company_client.rb
@@ -33,13 +33,13 @@ module BankApi::Clients
       ].any?(&:nil?)
     end
 
-    def get_balance(account_number)
+    def get_balance(options)
       login
       goto_balance
-      select_account(account_number)
+      select_account(options[:account_number])
       click_fetch_balance_button
       {
-        account_number: account_number,
+        account_number: options[:account_number],
         available_balance: money_to_i(read_balance(:available)),
         countable_balance: money_to_i(read_balance(:countable))
       }

--- a/lib/bank_api/clients/banco_security/company_client.rb
+++ b/lib/bank_api/clients/banco_security/company_client.rb
@@ -30,11 +30,11 @@ module BankApi::Clients::BancoSecurity
       :security
     end
 
-    def get_balance(account_number)
+    def get_balance(options)
       login
-      goto_company_dashboard
+      goto_company_dashboard(options[:rut] || @company_rut)
       goto_balance
-      find_account_balance(account_number)
+      find_account_balance(options[:account_number])
     ensure
       browser.close
     end

--- a/lib/bank_api/clients/banco_security/concerns/balance.rb
+++ b/lib/bank_api/clients/banco_security/concerns/balance.rb
@@ -7,6 +7,11 @@ module BankApi::Clients::BancoSecurity
     COUNTABLE_BALANCE_COLUMN = 2
 
     def find_account_balance(account_number)
+      return get_balance_from_accounts_list(account_number) if account_number
+      get_balance_from_account_summary
+    end
+
+    def get_balance_from_accounts_list(account_number)
       balance = browser.search(".cuentas-corrientes").search("tbody tr").map do |row|
         cells = row.search("td")
         {
@@ -17,19 +22,41 @@ module BankApi::Clients::BancoSecurity
       end.find do |row|
         row[:account_number] == account_number
       end
-      validate_balance(balance, account_number)
+      validate_account_balance(balance, account_number)
       balance
     end
 
-    def money_to_i(text)
-      text.delete(".").delete("$").delete(" ").to_i
+    def get_balance_from_account_summary
+      available_balance = extract_balance(1)
+      countable_balance = extract_balance(2)
+      validate_summary_balance(available_balance, countable_balance)
+
+      {
+        available_balance: available_balance,
+        countable_balance: countable_balance
+      }
     end
 
-    def validate_balance(balance, account_number)
+    def validate_account_balance(balance, account_number)
       if balance.nil?
         raise BankApi::Balance::InvalidAccountNumber, "Couldn't find balance of account " +
           account_number.to_s
       end
+    end
+
+    def validate_summary_balance(available_balance, countable_balance)
+      if available_balance.zero? || countable_balance.zero?
+        raise BankApi::Balance::MissingAccountBalance, "Couldn't find balance"
+      end
+    end
+
+    def extract_balance(td_pos)
+      xp = "//*[@id=\"body\"]/div[1]/section/div/div/div[3]/div[2]/table/tbody/tr[1]/td[#{td_pos}]"
+      money_to_i(browser.search(xpath: xp).text)
+    end
+
+    def money_to_i(text)
+      text.to_s.delete(".").delete("$").delete(" ").to_i
     end
   end
 end

--- a/lib/bank_api/clients/base_client.rb
+++ b/lib/bank_api/clients/base_client.rb
@@ -16,9 +16,9 @@ module BankApi::Clients
       parse_entries(get_deposits(options))
     end
 
-    def get_account_balance(account_number)
+    def get_account_balance(options)
       validate_credentials
-      get_balance(account_number)
+      get_balance(options)
     end
 
     def transfer(transfer_data)
@@ -51,7 +51,7 @@ module BankApi::Clients
       raise NotImplementedError
     end
 
-    def get_balance
+    def get_balance(_options = {})
       raise NotImplementedError
     end
 

--- a/lib/bank_api/exceptions.rb
+++ b/lib/bank_api/exceptions.rb
@@ -2,6 +2,7 @@ module BankApi
   class MissingCredentialsError < StandardError; end
   module Balance
     class InvalidAccountNumber < StandardError; end
+    class MissingAccountBalance < StandardError; end
   end
   module Deposit
     class QuantityError < StandardError; end

--- a/spec/bank_api/clients/banco_de_chile_company_client_spec.rb
+++ b/spec/bank_api/clients/banco_de_chile_company_client_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe BankApi::Clients::BancoDeChileCompanyClient do
   def mock_get_balance_navigation
     allow(subject).to receive(:login)
     allow(subject).to receive(:goto_balance)
-    allow(subject).to receive(:select_account).with(account_number)
+    allow(subject).to receive(:select_account).with(options[:account_number])
     allow(subject).to receive(:click_fetch_balance_button)
   end
 
@@ -203,7 +203,11 @@ RSpec.describe BankApi::Clients::BancoDeChileCompanyClient do
   describe 'get_balance' do
     let(:search_countable) { double }
     let(:search_available) { double }
-    let(:account_number) { 123456789 }
+    let(:options) do
+      {
+        account_number: 123456789
+      }
+    end
 
     before do
       mock_validate_credentials
@@ -220,11 +224,11 @@ RSpec.describe BankApi::Clients::BancoDeChileCompanyClient do
 
     it 'returns the balance hash' do
       expect(subject).to receive(:validate_credentials)
-      res = subject.get_account_balance(account_number)
+      res = subject.get_account_balance(options)
       expect(res.keys).to include(:account_number, :available_balance, :countable_balance)
       expect(res[:available_balance]).to eq(445070)
       expect(res[:countable_balance]).to eq(400070)
-      expect(res[:account_number]).to eq(account_number)
+      expect(res[:account_number]).to eq(options[:account_number])
     end
 
     context "with navigation error" do

--- a/spec/bank_api/clients/banco_security/concerns/balance_spec.rb
+++ b/spec/bank_api/clients/banco_security/concerns/balance_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe BankApi::Clients::BancoSecurity::Deposits do
   let(:browser) { double(config: { wait_timeout: 1.0, wait_interval: 0.1 }) }
   let(:div) { double(text: 'text') }
   let(:dynamic_card) { double }
+  let(:account_number) { "11" }
 
   class DummyClass < BankApi::Clients::BaseClient
     include BankApi::Clients::BancoSecurity::Balance
@@ -17,52 +18,102 @@ RSpec.describe BankApi::Clients::BancoSecurity::Deposits do
     end
   end
 
+  def perform
+    dummy.find_account_balance(account_number)
+  end
+
   let(:dummy) { DummyClass.new }
 
-  let(:first_row) { double }
-  let(:second_row) { double }
-  let(:table) { [first_row, second_row] }
+  before { allow(dummy).to receive(:browser).and_return(browser) }
 
-  def mock_table
-    allow(div).to receive(:search).with('tbody tr').and_return(table)
-    allow(first_row).to receive(:search).with("td").and_return(
-      [double(text: "11"), double(text: "$ 1.000"), double(text: "$ 2.000")]
-    )
-    allow(second_row).to receive(:search).with("td").and_return(
-      [double(text: "12"), double(text: "$ 4.000"), double(text: "$ 6.000")]
-    )
-  end
+  context "with account number" do
+    let(:first_row) { double }
+    let(:second_row) { double }
+    let(:table) { [first_row, second_row] }
 
-  before do
-    mock_table
-    allow(dummy).to receive(:browser).and_return(browser)
-
-    allow(browser).to receive(:search).and_return(div)
-    allow(browser).to receive(:goto)
-  end
-
-  context "with present account_number" do
-    it "returns expected balance" do
-      expect(dummy.find_account_balance("11")).to eq(
-        account_number: "11",
-        available_balance: 1000,
-        countable_balance: 2000
+    def mock_table
+      allow(div).to receive(:search).with('tbody tr').and_return(table)
+      allow(first_row).to receive(:search).with("td").and_return(
+        [double(text: "11"), double(text: "$ 1.000"), double(text: "$ 2.000")]
       )
-
-      expect(dummy.find_account_balance("12")).to eq(
-        account_number: "12",
-        available_balance: 4000,
-        countable_balance: 6000
+      allow(second_row).to receive(:search).with("td").and_return(
+        [double(text: "12"), double(text: "$ 4.000"), double(text: "$ 6.000")]
       )
+    end
+
+    before do
+      mock_table
+      allow(browser).to receive(:search).and_return(div)
+      allow(browser).to receive(:goto)
+    end
+
+    context "with present account_number" do
+      it "returns expected balance" do
+        expect(perform).to eq(
+          account_number: account_number,
+          available_balance: 1000,
+          countable_balance: 2000
+        )
+      end
+    end
+
+    context "with another account_number" do
+      let(:account_number) { "12" }
+
+      it "returns expected balance" do
+        expect(perform).to eq(
+          account_number: account_number,
+          available_balance: 4000,
+          countable_balance: 6000
+        )
+      end
+    end
+
+    context "with invalid account_number" do
+      let(:account_number) { "1" }
+
+      it "returns expected balance" do
+        expect { perform }.to raise_error(
+          BankApi::Balance::InvalidAccountNumber,
+          "Couldn't find balance of account 1"
+        )
+      end
     end
   end
 
-  context "without present account_number" do
-    it "returns expected balance" do
-      expect { dummy.find_account_balance("1") }.to raise_error(
-        BankApi::Balance::InvalidAccountNumber,
-        "Couldn't find balance of account 1"
-      )
+  context "without account_number" do
+    def mock_account_balance_extraction(td_pos, capital)
+      xp = "//*[@id=\"body\"]/div[1]/section/div/div/div[3]/div[2]/table/tbody/tr[1]/td[#{td_pos}]"
+      expect(browser).to receive(:search).with(xpath: xp).and_return(double(text: capital))
+    end
+
+    let(:account_number) { nil }
+
+    context "with found balance" do
+      before do
+        mock_account_balance_extraction(1, "$ 194.024.778")
+        mock_account_balance_extraction(2, "$ 174.024.666")
+      end
+
+      it { expect(perform).to eq(available_balance: 194024778, countable_balance: 174024666) }
+    end
+
+    context "with available_balance not found" do
+      before do
+        mock_account_balance_extraction(1, "")
+        mock_account_balance_extraction(2, "$ 174.024.666")
+      end
+
+      it { expect { perform }.to raise_error(BankApi::Balance::MissingAccountBalance) }
+    end
+
+    context "with countable_balance not found" do
+      before do
+        mock_account_balance_extraction(1, "$ 194.024.778")
+        mock_account_balance_extraction(2, nil)
+      end
+
+      it { expect { perform }.to raise_error(BankApi::Balance::MissingAccountBalance) }
     end
   end
 end


### PR DESCRIPTION
Necesité cambiar acá para sacar los balances de los fondos:

Antes era así:

```ruby
BankApi.get_bdc_account_balance("xxx")
BankApi::BancoSecurity.get_account_balance("xxx")
```

Ahora es así: 

```ruby
BankApi.get_bdc_account_balance(account_number: "xxx")
BankApi::BancoSecurity.get_account_balance(account_number: "xxx") # para la administradora.
BankApi::BancoSecurity.get_account_balance(rut: "rut_del_fondo") # para un fondo
```

Tener en cuenta:

- Si no va el parámetro `rut` usa el de la configuración global (el de la administradora)
- para saca el balance de los fondos no se usa el parámetro `account_number`. Ya que sólo tienen una cuenta y en el banco no aparece la vista para seleccionar esa única cuenta. Entra directmente al summary.