### PR TITLE
fix(security deposits): change method to extract client name

### DIFF
--- a/lib/bank_api/clients/banco_security/concerns/deposits.rb
+++ b/lib/bank_api/clients/banco_security/concerns/deposits.rb
@@ -80,9 +80,7 @@ module BankApi::Clients::BancoSecurity
     end
 
     def extract_client_name(text)
-      parts = text.to_s.split(" De ")
-      parts = text.to_s.split(" DE ") if parts.count == 1
-      return text if parts.count > 2
+      parts = text.to_s.split(/\ DE | De | de /, 2)
       parts.last.to_s.strip
     end
 

--- a/spec/bank_api/clients/banco_security/concerns/deposits_spec.rb
+++ b/spec/bank_api/clients/banco_security/concerns/deposits_spec.rb
@@ -111,7 +111,9 @@ RSpec.describe BankApi::Clients::BancoSecurity::Deposits do
   context "with deposits from account details" do
     let(:txt_file) do
       content = <<~DOC
-        Nombre;Direcci\xF3n;Comuna;Ciudad;Cuenta;Moneda;Cartola;Desde;Hasta;Fecha cartola anterior;Saldo final cartola anterior;Ejecutivo;Oficina;Tel\xE9fono;L\xEDnea de Cr\xE9dito Monto utilizado;L\xEDnea de Cr\xE9dito Monto Disponible;Vencimiento\r\LEANS ADMINISTRADORA GENERAL DE FONDOS S A;LOS CONQUISTADORES 111, PROVIDENCIA, SANTIAGO;PROVIDENCIA;SANTIAGO;666698607;CLP;Provisoria;666666;7777777;Fecha cartola anterior en duro;;LEAN SEGOVIA;EL GOLF;2342342234;0;0.0;4334334\r\nFecha;Descripci\xF3n;N de documento;Cargos;Abonos;Saldo\r\n12/09;TRANSFERENCIA DESDE Banco Santander De ALICIA FORTUNATO ; 00056290667;0.00;180,000.00;47,300,662.00\r\n12/09;TRANSFERENCIA DESDE Banco Santander De SANDRA VILLANUEVA; 00056290549;0.00;2,230,000.00;47,120,662.00\r\n12/09;TRANSFERENCIA DESDE BANCO SECURITY DE LEANDRO SEGOVIA ; 00056290121;0.00;300,000.00;44,890,662.00\r\n12/09;TRANSFERENCIA A Banco Santander PARA Mario Ruiz Tagle; 00056288530;199,073.00;0.00;44,590,662.00\r\n12/09;TRANSFERENCIA A BCI PARA Juan Bustos Cavada ; 00056288222;4,150,374.00;0.00;44,789,735.00\r\n12/09;TRANSFERENCIA A Banco Chile-Edwards-Citi PARA Javier Andr s Soto  ; 00056288091;92,000.00;0.00;48,940,109.00\r\n12/09;TRANSFERENCIA A Banco Santander PARA Sebastian Ortega; 00056287857;2,231,196.00;0.00;49,032,109.00\r\n03/09;TRANSFERENCIA DESDE BBVA De SILVA DAURO ; 00054935695;0.00;50,000.00;93,342,708.00\r\n03/09;SALDO INICIAL;;0.00;0.00;93,292,708.00\r\nResumen del per\xEDodo\r\nSaldo inicial;Total cargos;Total abonos;Saldo final\r\n93,292,708.00;696,761,603.00;650,769,557.00;93,292,708.00\r\nCheques pagados\r\n;;;;;\r\nCheques devueltos\r\n;;;;;\r\n
+        Nombre;Direcci\xF3n;Comuna;Ciudad;Cuenta;Moneda;Cartola;Desde;Hasta;Fecha cartola anterior;Saldo final cartola anterior;Ejecutivo;Oficina;Tel\xE9fono;L\xEDnea de Cr\xE9dito Monto utilizado;L\xEDnea de Cr\xE9dito Monto Disponible;Vencimiento\r\LEANS ADMINISTRADORA GENERAL DE FONDOS S A;LOS CONQUISTADORES 111, PROVIDENCIA, SANTIAGO;PROVIDENCIA;SANTIAGO;666698607;CLP;Provisoria;666666;7777777;Fecha cartola anterior en duro;;LEAN SEGOVIA;EL GOLF;2342342234;0;0.0;4334334\r\nFecha;Descripci\xF3n;N de documento;Cargos;Abonos;Saldo\r\n12/09;TRANSFERENCIA DESDE Banco Santander De ALICIA FORTUNATO ; 00056290667;0.00;180,000.00;47,300,662.00\r\n12/09;TRANSFERENCIA DESDE Banco Santander De SANDRA VILLANUEVA; 00056290549;0.00;2,230,000.00;47,120,662.00\r\n12/09;TRANSFERENCIA DESDE BANCO SECURITY DE LEANDRO SEGOVIA ; 00056290121;0.00;300,000.00;44,890,662.00\r\n24/10;TRANSFERENCIA
+        DESDE Banco Santander De CAMILO DE LOS REYES; 00056290549;0.00;2,450,000.00;47,120,662.00\r\n12/09;TRANSFERENCIA A Banco Santander PARA Mario Ruiz Tagle; 00056288530;199,073.00;0.00;44,590,662.00\r\n12/09;TRANSFERENCIA A BCI PARA Juan Bustos Cavada ; 00056288222;4,150,374.00;0.00;44,789,735.00\r\n12/09;TRANSFERENCIA A Banco Chile-Edwards-Citi PARA Javier Andr s Soto  ; 00056288091;92,000.00;0.00;48,940,109.00\r\n12/09;TRANSFERENCIA A
+        Banco Santander PARA Sebastian Ortega; 00056287857;2,231,196.00;0.00;49,032,109.00\r\n03/09;TRANSFERENCIA DESDE BBVA De SILVA DAURO ; 00054935695;0.00;50,000.00;93,342,708.00\r\n03/09;SALDO INICIAL;;0.00;0.00;93,292,708.00\r\nResumen del per\xEDodo\r\nSaldo inicial;Total cargos;Total abonos;Saldo final\r\n93,292,708.00;696,761,603.00;650,769,557.00;93,292,708.00\r\nCheques pagados\r\n;;;;;\r\nCheques devueltos\r\n;;;;;\r\n
       DOC
 
       double(content: content)
@@ -126,6 +128,13 @@ RSpec.describe BankApi::Clients::BancoSecurity::Deposits do
             date: Date.parse('03/09/2018'),
             time: nil,
             amount: 50000
+          },
+          {
+            client: "CAMILO DE LOS REYES",
+            rut: nil,
+            date: Date.parse('24/10/2018'),
+            time: nil,
+            amount: 2450000
           },
           {
             client: "LEANDRO SEGOVIA",


### PR DESCRIPTION
Cambia la forma en que extrae el nombre del cliente, ahora busca por regex la primera ocurrencia de `" DE "`, `" De "` o `" de "` y retorna el resto. Resuelve el problema para caso donde el usuario tenga apellido que incluya `de`.